### PR TITLE
Add three-phase stator rotating-field workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,19 @@ jobs:
           ./build/motor_sim --scenario inputs/tests/rotor_ripple_test.json --solve --outputs all --parallel-frames --max-iters 40000 --tol 2.5e-6
       - name: Verify VTK export
         run: python3 python/verify_vtk.py outputs/rotor_ripple_field_frame_000.vti
+      - name: Three-phase stator rotating-field demo
+        env:
+          MPLBACKEND: Agg
+        run: |
+          set -euo pipefail
+          python3 python/gen_three_phase_stator.py --profile ci --out inputs/three_phase_stator_ci.json
+          ./build/motor_sim --scenario inputs/three_phase_stator_ci.json --solve --parallel-frames --vtk-series outputs/three_phase_ci.pvd --tol 5e-6 --max-iters 40000
+          python3 python/check_three_phase_field.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json
+          python3 python/animate_three_phase.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json --save ci_artifacts/three_phase_demo.gif
+          cp outputs/three_phase_frame_frame_000.vti ci_artifacts/
+          cp outputs/three_phase_ci.pvd ci_artifacts/
+          cp outputs/bore_angle.csv ci_artifacts/
+          cp outputs/three_phase_outlines.vtp ci_artifacts/
       - name: Render visualisations
         env:
           MPLBACKEND: Agg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           python3 python/gen_three_phase_stator.py --profile ci --out inputs/three_phase_stator_ci.json
           ./build/motor_sim --scenario inputs/three_phase_stator_ci.json --solve --parallel-frames --vtk-series outputs/three_phase_ci.pvd --tol 5e-6 --max-iters 40000
           python3 python/check_three_phase_field.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json
-          python3 python/animate_three_phase.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json --save ci_artifacts/three_phase_demo.gif
+          python3 python/animate_three_phase.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json --save ci_artifacts/three_phase_demo.gif --frame-png ci_artifacts/three_phase_demo.png
           cp outputs/three_phase_frame_frame_000.vti ci_artifacts/
           cp outputs/three_phase_ci.pvd ci_artifacts/
           cp outputs/bore_angle.csv ci_artifacts/

--- a/docs/three_phase_stator.md
+++ b/docs/three_phase_stator.md
@@ -1,0 +1,71 @@
+# Three-Phase Stator Scenario
+
+This scenario bundles a six-slot, two-pole three-phase stator that drives a
+balanced rotating field. The Python generator produces both the tiny CI-sized
+case and a high-resolution configuration by tweaking a single profile flag.
+
+## Quickstart
+
+```bash
+python3 python/gen_three_phase_stator.py --profile ci --out inputs/three_phase_stator_ci.json
+./build/motor_sim --scenario inputs/three_phase_stator_ci.json --solve --parallel-frames --vtk-series outputs/three_phase_ci.pvd --tol 5e-6 --max-iters 40000
+python3 python/animate_three_phase.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json --save three_phase_demo.mp4
+```
+
+The generated scenario exports cell-centred VTK frames, a bore-average CSV, and
+polyline outlines that highlight the stator geometry.
+
+## Scaling up
+
+The generator exposes two profiles:
+
+- `ci`: 65×65 grid, 12 frames (one electrical cycle)
+- `hires`: 401×401 grid, 120 frames per cycle, three electrical cycles
+
+Switch profiles via `--profile hires` to emit the high-resolution configuration.
+All other pipeline steps remain unchanged—simply re-run `motor_sim` and the
+animation command on the new JSON.
+
+## Outputs
+
+- `outputs/three_phase_frame_###.vti`: per-frame cell-centred B/H fields.
+- `outputs/three_phase_ci.pvd`: ParaView time-series index (generated via
+  `--vtk-series`).
+- `outputs/three_phase_outlines.vtp`: geometry polylines for overlaying slot
+  and stator boundaries.
+- `outputs/bore_angle.csv`: bore-average B components, magnitudes, and angles.
+
+## ParaView tips
+
+1. Open the `.pvd` series to load the time-resolved field data.
+2. Add `three_phase_outlines.vtp` as a separate source and enable it in the
+   pipeline to overlay slot and stator geometry.
+3. Use the “Glyph” filter on `three_phase_outlines.vtp` for quick directional
+   cues, or switch the VTI representation to “Surface LIC” for streamline-like
+   visuals.
+
+## Animation
+
+`python/animate_three_phase.py` renders a two-panel animation that combines the
+bore-averaged field direction with the driving phase currents. The CLI accepts:
+
+- `--pvd`: VTK time-series index produced by `motor_sim --vtk-series`.
+- `--scenario`: scenario JSON (required to extract timeline currents and bore
+  polygon).
+- `--save`: output path (MP4/GIF; binaries are uploaded as CI artefacts rather
+  than committed).
+- `--fps` and `--width`: tune playback speed and output resolution.
+
+The animation is designed for the CI demo case and remains lightweight enough
+for larger offline runs.
+
+## Notes
+
+- The stator slots are modelled as uniform current regions that draw their
+  per-frame currents from `phase_currents` entries in the timeline.
+- The bore-average sanity check (`python/check_three_phase_field.py`) unwraps
+  the bore field angle, verifies monotonic rotation, enforces an R² > 0.95 fit
+  against a straight line, and guards against magnitude collapse. The CI
+  workflow runs it automatically.
+- Keep binary artefacts (MP4/VTI samples) out of git history. The CI workflow
+  uploads a small bundle with the demo VTK frame, bore CSV, and animation.

--- a/docs/three_phase_stator.md
+++ b/docs/three_phase_stator.md
@@ -9,7 +9,7 @@ case and a high-resolution configuration by tweaking a single profile flag.
 ```bash
 python3 python/gen_three_phase_stator.py --profile ci --out inputs/three_phase_stator_ci.json
 ./build/motor_sim --scenario inputs/three_phase_stator_ci.json --solve --parallel-frames --vtk-series outputs/three_phase_ci.pvd --tol 5e-6 --max-iters 40000
-python3 python/animate_three_phase.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json --save three_phase_demo.mp4
+python3 python/animate_three_phase.py --pvd outputs/three_phase_ci.pvd --scenario inputs/three_phase_stator_ci.json --save three_phase_demo.mp4 --frame-png three_phase_demo.png
 ```
 
 The generated scenario exports cell-centred VTK frames, a bore-average CSV, and
@@ -47,8 +47,8 @@ animation command on the new JSON.
 ## Animation
 
 `python/animate_three_phase.py` renders a full-field animation that overlays the
-cell-centred |B| map, quiver arrows, bore compass, and the driving phase
-currents. The CLI accepts:
+cell-centred |B| map, quiver arrows, bore compass, labelled slot outlines, and
+the driving phase currents. The CLI accepts:
 
 - `--pvd`: VTK time-series index produced by `motor_sim --vtk-series`.
 - `--scenario`: scenario JSON (required to extract timeline currents and bore

--- a/docs/three_phase_stator.md
+++ b/docs/three_phase_stator.md
@@ -46,8 +46,9 @@ animation command on the new JSON.
 
 ## Animation
 
-`python/animate_three_phase.py` renders a two-panel animation that combines the
-bore-averaged field direction with the driving phase currents. The CLI accepts:
+`python/animate_three_phase.py` renders a full-field animation that overlays the
+cell-centred |B| map, quiver arrows, bore compass, and the driving phase
+currents. The CLI accepts:
 
 - `--pvd`: VTK time-series index produced by `motor_sim --vtk-series`.
 - `--scenario`: scenario JSON (required to extract timeline currents and bore
@@ -55,6 +56,11 @@ bore-averaged field direction with the driving phase currents. The CLI accepts:
 - `--save`: output path (MP4/GIF; binaries are uploaded as CI artefacts rather
   than committed).
 - `--fps` and `--width`: tune playback speed and output resolution.
+- `--html`: emit an interactive HTML player (uses the same data as the MP4).
+- `--frame-png`: write a static render of the first frame (handy for docs or
+  quick inspection).
+- `--log-scale`: switch the |B| colour map to logarithmic scaling to emphasise
+  the field in low-magnitude regions.
 
 The animation is designed for the CI demo case and remains lightweight enough
 for larger offline runs.

--- a/include/motorsim/ingest.hpp
+++ b/include/motorsim/ingest.hpp
@@ -19,6 +19,20 @@ struct ScenarioSpec {
         double current{0.0};
     };
 
+    struct CurrentRegion {
+        std::string id;
+        std::string phase;
+        double orientation{1.0};
+        std::vector<double> xs;
+        std::vector<double> ys;
+        double min_x{0.0};
+        double max_x{0.0};
+        double min_y{0.0};
+        double max_y{0.0};
+        double area{0.0};
+        double current{0.0};
+    };
+
     struct Rotor {
         std::string name;
         double pivotX{0.0};
@@ -81,6 +95,15 @@ struct ScenarioSpec {
             std::string format;    // e.g., "csv"
         };
 
+        struct VtkSeries {
+            std::string id;
+            std::string directory;
+            std::string basename;
+            bool includeB{true};
+            bool includeH{true};
+            bool includeEnergy{false};
+        };
+
         struct LineProbe {
             std::string id;
             std::string path;
@@ -118,14 +141,34 @@ struct ScenarioSpec {
             std::vector<std::size_t> frameIndices;
         };
 
+        struct PolylineOutlines {
+            std::string id;
+            std::string path;
+        };
+
+        struct BoreAverageProbe {
+            std::string id;
+            std::vector<double> xs;
+            std::vector<double> ys;
+            std::string path;
+        };
+
         std::vector<FieldMap> fieldMaps;
+        std::vector<VtkSeries> vtkSeries;
         std::vector<LineProbe> lineProbes;
         std::vector<Probe> probes;
         std::vector<BackEmfProbe> backEmfProbes;
+        std::vector<PolylineOutlines> polylineOutlines;
+        std::vector<BoreAverageProbe> boreProbes;
     };
 
     struct TimelineFrame {
         struct WireOverride {
+            std::size_t index{0};
+            double current{0.0};
+        };
+
+        struct CurrentRegionOverride {
             std::size_t index{0};
             double current{0.0};
         };
@@ -149,6 +192,7 @@ struct ScenarioSpec {
         double rotorAngleDeg{0.0};
         std::vector<RotorAngleOverride> rotorAngles;
         std::vector<WireOverride> wireOverrides;
+        std::vector<CurrentRegionOverride> currentRegionOverrides;
         std::vector<MagnetOverride> magnetOverrides;
     };
 
@@ -167,6 +211,7 @@ struct ScenarioSpec {
     std::vector<PolygonRegion> polygons;
     std::vector<RegionMask> regionMasks;
     std::vector<Wire> wires;
+    std::vector<CurrentRegion> currentRegions;
     std::vector<Rotor> rotors;
     std::vector<MagnetRegion> magnetRegions;
     BoundaryType boundaryType{BoundaryType::Dirichlet};

--- a/include/motorsim/io_vtk.hpp
+++ b/include/motorsim/io_vtk.hpp
@@ -12,6 +12,7 @@ struct VtkOutlineLoop {
         Material = 1,
         Magnet = 2,
         Wire = 3,
+        CurrentRegion = 4,
     };
 
     Kind kind{Kind::Domain};
@@ -46,6 +47,13 @@ void write_vti_field_map(const std::string& path,
 // groupings (e.g. rotor assemblies) can be reconstructed without relying on
 // VTK string arrays.
 void write_vtp_outlines(const std::string& path, const std::vector<VtkOutlineLoop>& loops);
+
+struct PvdDataSet {
+    double time{0.0};
+    std::string file;
+};
+
+void write_pvd_series(const std::string& path, const std::vector<PvdDataSet>& datasets);
 
 }  // namespace motorsim
 

--- a/include/motorsim/solver.hpp
+++ b/include/motorsim/solver.hpp
@@ -6,7 +6,18 @@
 
 #include "grid.hpp"
 
+#include <chrono>
+#include <functional>
+
 namespace motorsim {
+
+/**
+ * @brief Snapshot of the iterative solver's progress.
+ */
+struct SolverProgress {
+    std::size_t iteration{0};
+    double relResidual{0.0};
+};
 
 /**
  * @brief Solver options controlling the Gauss–Seidel / SOR iteration.
@@ -16,6 +27,8 @@ struct SolveOptions {
     double tol{1e-6};
     double omega{1.7};
     bool verbose{false};
+    std::chrono::steady_clock::duration progressInterval{std::chrono::steady_clock::duration::zero()};
+    std::function<void(const SolverProgress&)> progressCallback{};
 };
 
 /**

--- a/python/animate_three_phase.py
+++ b/python/animate_three_phase.py
@@ -1,0 +1,254 @@
+"""Create animations for the three-phase stator rotating field."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
+import numpy as np
+import vtk  # type: ignore
+from matplotlib.patches import FancyArrowPatch
+from vtk.util.numpy_support import vtk_to_numpy  # type: ignore
+
+
+def point_in_polygon(x: float, y: float, vertices: np.ndarray) -> bool:
+    inside = False
+    count = vertices.shape[0]
+    for i in range(count):
+        j = (i - 1) % count
+        xi, yi = vertices[i]
+        xj, yj = vertices[j]
+        intersect = ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi)
+        if intersect:
+            inside = not inside
+    return inside
+
+
+def load_scenario(path: Path) -> Dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_pvd(path: Path) -> List[Tuple[float, Path]]:
+    root = ET.fromstring(path.read_text(encoding="utf-8"))
+    datasets: List[Tuple[float, Path]] = []
+    base_dir = path.parent
+    for dataset in root.findall(".//DataSet"):
+        timestep = float(dataset.attrib.get("timestep", "0.0"))
+        file_attr = dataset.attrib.get("file")
+        if not file_attr:
+            continue
+        datasets.append((timestep, (base_dir / file_attr).resolve()))
+    datasets.sort(key=lambda item: item[0])
+    return datasets
+
+
+def extract_bore_polygon(scenario: Dict[str, object]) -> np.ndarray:
+    outputs = scenario.get("outputs", [])
+    for output in outputs:
+        if isinstance(output, dict) and output.get("type") in {"bore_avg_B", "bore_avg_b"}:
+            vertices = output.get("vertices") or output.get("polygon")
+            if isinstance(vertices, dict):
+                vertices = vertices.get("vertices")
+            if isinstance(vertices, list) and vertices:
+                return np.asarray(vertices, dtype=float)
+    # Fallback: use bore radius from geometry
+    domain = scenario.get("domain", {})
+    nx = int(domain.get("nx", 1))
+    ny = int(domain.get("ny", 1))
+    Lx = float(domain.get("Lx", 1.0))
+    dx = Lx / max(nx - 1, 1)
+    radius = 0.5 * Lx * 0.3
+    segments = 64
+    vertices = np.array(
+        [[radius * math.cos(2.0 * math.pi * i / segments), radius * math.sin(2.0 * math.pi * i / segments)] for i in range(segments)],
+        dtype=float,
+    )
+    return vertices
+
+
+def load_phase_currents(scenario: Dict[str, object]) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    timeline = scenario.get("timeline", [])
+    times = []
+    currents_a = []
+    currents_b = []
+    currents_c = []
+    for entry in timeline:
+        if not isinstance(entry, dict):
+            continue
+        time = float(entry.get("t", entry.get("time", len(times))))
+        phases = entry.get("phase_currents", {})
+        times.append(time)
+        currents_a.append(float(phases.get("A", 0.0)))
+        currents_b.append(float(phases.get("B", 0.0)))
+        currents_c.append(float(phases.get("C", 0.0)))
+    return (
+        np.asarray(times, dtype=float),
+        np.asarray(currents_a, dtype=float),
+        np.asarray(currents_b, dtype=float),
+        np.asarray(currents_c, dtype=float),
+    )
+
+
+def compute_bore_series(datasets: List[Tuple[float, Path]], bore_polygon: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    times = []
+    bx_values = []
+    by_values = []
+    for time, vti_path in datasets:
+        reader = vtk.vtkXMLImageDataReader()
+        reader.SetFileName(str(vti_path))
+        reader.Update()
+        data = reader.GetOutput()
+        cell_data = data.GetCellData()
+        bx_array = cell_data.GetArray("Bx")
+        by_array = cell_data.GetArray("By")
+        if bx_array is None or by_array is None:
+            raise RuntimeError(f"VTK file {vti_path} is missing Bx/By arrays")
+        bx = vtk_to_numpy(bx_array)
+        by = vtk_to_numpy(by_array)
+        dims = data.GetDimensions()
+        spacing = data.GetSpacing()
+        origin = data.GetOrigin()
+        cell_nx = max(dims[0] - 1, 1)
+        cell_ny = max(dims[1] - 1, 1)
+        bx = bx.reshape((cell_ny, cell_nx))
+        by = by.reshape((cell_ny, cell_nx))
+        mask = np.zeros((cell_ny, cell_nx), dtype=bool)
+        for j in range(cell_ny):
+            y = origin[1] + (j + 0.5) * spacing[1]
+            for i in range(cell_nx):
+                x = origin[0] + (i + 0.5) * spacing[0]
+                if point_in_polygon(x, y, bore_polygon):
+                    mask[j, i] = True
+        if not np.any(mask):
+            raise RuntimeError(f"Bore polygon did not overlap any cells in {vti_path}")
+        avg_bx = float(np.mean(bx[mask]))
+        avg_by = float(np.mean(by[mask]))
+        times.append(time)
+        bx_values.append(avg_bx)
+        by_values.append(avg_by)
+    return np.asarray(times, dtype=float), np.asarray(bx_values, dtype=float), np.asarray(by_values, dtype=float)
+
+
+def build_animation(
+    save_path: Path,
+    datasets: List[Tuple[float, Path]],
+    phase_times: np.ndarray,
+    currents_a: np.ndarray,
+    currents_b: np.ndarray,
+    currents_c: np.ndarray,
+    bore_times: np.ndarray,
+    bore_bx: np.ndarray,
+    bore_by: np.ndarray,
+    bore_polygon: np.ndarray,
+    fps: int,
+    width: int,
+) -> None:
+    bore_magnitude = np.hypot(bore_bx, bore_by)
+    max_mag = float(np.max(bore_magnitude)) if bore_magnitude.size > 0 else 1.0
+    bore_angles = np.arctan2(bore_by, bore_bx)
+
+    fig_width_in = width / 100.0
+    fig_height_in = fig_width_in * 0.75
+    fig, (ax_compass, ax_currents) = plt.subplots(
+        2,
+        1,
+        figsize=(fig_width_in, fig_height_in),
+        gridspec_kw={"height_ratios": [2, 1]},
+    )
+
+    bore_radius = np.max(np.linalg.norm(bore_polygon, axis=1)) if bore_polygon.size else 1.0
+    circle = plt.Circle((0.0, 0.0), bore_radius, fill=False, color="tab:gray", lw=1.5)
+    ax_compass.add_patch(circle)
+    ax_compass.set_aspect("equal", adjustable="datalim")
+    padding = bore_radius * 1.2
+    ax_compass.set_xlim(-padding, padding)
+    ax_compass.set_ylim(-padding, padding)
+    ax_compass.axis("off")
+    arrow = FancyArrowPatch((0.0, 0.0), (0.0, 0.0), color="tab:orange", arrowstyle="->", linewidth=2.0)
+    ax_compass.add_patch(arrow)
+    angle_text = ax_compass.text(0.02, 0.95, "", transform=ax_compass.transAxes, ha="left", va="top")
+
+    ax_currents.plot(phase_times, currents_a, label="Ia", color="tab:red")
+    ax_currents.plot(phase_times, currents_b, label="Ib", color="tab:green")
+    ax_currents.plot(phase_times, currents_c, label="Ic", color="tab:blue")
+    ax_currents.set_xlabel("Time [s]")
+    ax_currents.set_ylabel("Current [A]")
+    ax_currents.legend(loc="upper right")
+    ax_currents.grid(True, alpha=0.3)
+    marker_line = ax_currents.axvline(phase_times[0] if phase_times.size else 0.0, color="k", linestyle="--")
+
+    def update(frame_idx: int) -> List[object]:
+        time = bore_times[frame_idx]
+        magnitude = bore_magnitude[frame_idx]
+        angle = bore_angles[frame_idx]
+        scale = 0.8 * bore_radius * (magnitude / max_mag if max_mag > 0 else 1.0)
+        dx = scale * math.cos(angle)
+        dy = scale * math.sin(angle)
+        arrow.set_positions((0.0, 0.0), (dx, dy))
+        angle_deg = math.degrees(angle)
+        angle_text.set_text(f"t={time:.4f} s\n|B|={magnitude:.3f} T\nangle={angle_deg:.1f}°")
+        marker_line.set_xdata([time, time])
+        return [arrow, angle_text, marker_line]
+
+    anim = animation.FuncAnimation(
+        fig,
+        update,
+        frames=len(datasets),
+        blit=False,
+        interval=1000 / fps,
+    )
+
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = save_path.suffix.lower()
+    if suffix == ".gif":
+        writer = animation.PillowWriter(fps=fps)
+    else:
+        writer = animation.FFMpegWriter(fps=fps)
+    anim.save(str(save_path), writer=writer)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pvd", type=Path, required=True, help="VTK time-series PVD file")
+    parser.add_argument("--scenario", type=Path, required=True, help="Scenario JSON used for the solve")
+    parser.add_argument("--save", type=Path, required=True, help="Output animation path (e.g. MP4)")
+    parser.add_argument("--fps", type=int, default=24, help="Animation frames per second (default: 24)")
+    parser.add_argument("--width", type=int, default=640, help="Figure width in pixels (default: 640)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    scenario = load_scenario(args.scenario)
+    datasets = load_pvd(args.pvd)
+    if not datasets:
+        raise RuntimeError("No datasets found in PVD file")
+    bore_polygon = extract_bore_polygon(scenario)
+    phase_times, ia, ib, ic = load_phase_currents(scenario)
+    bore_times, bore_bx, bore_by = compute_bore_series(datasets, bore_polygon)
+    if phase_times.size != bore_times.size:
+        raise RuntimeError("Timeline length and VTK frame count mismatch")
+    build_animation(
+        args.save,
+        datasets,
+        phase_times,
+        ia,
+        ib,
+        ic,
+        bore_times,
+        bore_bx,
+        bore_by,
+        bore_polygon,
+        fps=args.fps,
+        width=args.width,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/check_three_phase_field.py
+++ b/python/check_three_phase_field.py
@@ -1,0 +1,75 @@
+"""Sanity checks for the three-phase stator rotating field simulation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from animate_three_phase import (  # reuse data loaders
+    compute_bore_series,
+    extract_bore_polygon,
+    load_pvd,
+    load_scenario,
+)
+
+
+def compute_r_squared(x: np.ndarray, y: np.ndarray) -> float:
+    coeffs = np.polyfit(x, y, 1)
+    fit = np.polyval(coeffs, x)
+    ss_res = np.sum((y - fit) ** 2)
+    ss_tot = np.sum((y - np.mean(y)) ** 2)
+    return 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+
+
+def check_rotating_field(pvd_path: str, scenario_path: str) -> int:
+    scenario = load_scenario(Path(scenario_path))
+    datasets = load_pvd(Path(pvd_path))
+    if not datasets:
+        print("No datasets found in PVD file")
+        return 1
+    bore_polygon = extract_bore_polygon(scenario)
+    times, bx, by = compute_bore_series(datasets, bore_polygon)
+    magnitude = np.hypot(bx, by)
+    angles = np.unwrap(np.arctan2(by, bx))
+    diffs = np.diff(angles)
+    direction = 1.0 if np.mean(diffs) >= 0.0 else -1.0
+    projected = direction * diffs
+    min_step = float(np.min(projected)) if projected.size else 0.0
+    if min_step <= -2e-3:
+        print(
+            "Rotating field check FAILED: angular steps change sign (min projected Δ={:.4e})".format(
+                min_step
+            )
+        )
+        return 1
+    r_squared = compute_r_squared(times, angles)
+    if r_squared < 0.95:
+        print(f"Rotating field check FAILED: R^2={r_squared:.3f} < 0.95")
+        return 1
+    if np.min(magnitude) < 1e-4:
+        print("Rotating field check FAILED: |B| collapsed below threshold")
+        return 1
+    print(
+        "Rotating field check PASSED: angle monotonic, R^2={:.3f}, |B|min={:.4f}, min step={:.4e}".format(
+            r_squared, np.min(magnitude), min_step
+        )
+    )
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pvd", required=True, help="VTK time-series PVD file")
+    parser.add_argument("--scenario", required=True, help="Scenario JSON path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    exit(check_rotating_field(args.pvd, args.scenario))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/gen_three_phase_stator.py
+++ b/python/gen_three_phase_stator.py
@@ -100,13 +100,14 @@ def generate_scenario(profile: str, output_path: Path) -> None:
 
     slot_polygons: List[List[List[float]]] = []
     sources = []
-    for phase, orientation, angle, label in slot_definitions:
+    for phase, orientation, angle, slot_id in slot_definitions:
         polygon = build_slot_polygon(angle, slot_inner_radius, slot_outer_radius, slot_width_deg)
         slot_polygons.append(polygon)
         sources.append(
             {
                 "type": "current_region",
-                "id": label,
+                "id": slot_id,
+                "label": f"Phase {phase}{'+' if orientation > 0 else '-'}",
                 "phase": phase,
                 "orientation": orientation,
                 "vertices": polygon,

--- a/python/gen_three_phase_stator.py
+++ b/python/gen_three_phase_stator.py
@@ -1,0 +1,193 @@
+"""Generate three-phase stator scenarios with configurable resolution profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+DEFAULT_PROFILES: Dict[str, Dict[str, float | int]] = {
+    "ci": {
+        "nx": 65,
+        "ny": 65,
+        "frames_per_cycle": 12,
+        "cycles": 1,
+        "slot_depth": 0.010,
+        "slot_width_deg": 18.0,
+    },
+    "hires": {
+        "nx": 401,
+        "ny": 401,
+        "frames_per_cycle": 120,
+        "cycles": 3,
+        "slot_depth": 0.010,
+        "slot_width_deg": 12.0,
+    },
+}
+
+def build_circle(radius: float, segments: int) -> List[List[float]]:
+    return [
+        [radius * math.cos(2.0 * math.pi * i / segments), radius * math.sin(2.0 * math.pi * i / segments)]
+        for i in range(segments)
+    ]
+
+
+def build_slot_polygon(
+    center_angle_rad: float,
+    inner_radius: float,
+    outer_radius: float,
+    width_deg: float,
+) -> List[List[float]]:
+    half_width = math.radians(width_deg) * 0.5
+    angles = [center_angle_rad - half_width, center_angle_rad + half_width]
+    points = [
+        [inner_radius * math.cos(angles[0]), inner_radius * math.sin(angles[0])],
+        [outer_radius * math.cos(angles[0]), outer_radius * math.sin(angles[0])],
+        [outer_radius * math.cos(angles[1]), outer_radius * math.sin(angles[1])],
+        [inner_radius * math.cos(angles[1]), inner_radius * math.sin(angles[1])],
+    ]
+    return points
+
+
+def compute_phase_currents(current_amp: float, omega: float, time: float) -> Tuple[float, float, float]:
+    theta = omega * time
+    ia = current_amp * math.sin(theta)
+    ib = current_amp * math.sin(theta - 2.0 * math.pi / 3.0)
+    ic = current_amp * math.sin(theta + 2.0 * math.pi / 3.0)
+    return ia, ib, ic
+
+
+def generate_scenario(profile: str, output_path: Path) -> None:
+    if profile not in DEFAULT_PROFILES:
+        raise ValueError(f"Unknown profile '{profile}'. Available profiles: {', '.join(DEFAULT_PROFILES)}")
+
+    profile_cfg = DEFAULT_PROFILES[profile]
+    nx = int(profile_cfg["nx"])
+    ny = int(profile_cfg["ny"])
+    frames_per_cycle = int(profile_cfg["frames_per_cycle"])
+    cycles = int(profile_cfg["cycles"])
+    slot_depth = float(profile_cfg["slot_depth"])
+    slot_width_deg = float(profile_cfg["slot_width_deg"])
+
+    domain_size = 0.14
+    r_in = 0.040
+    r_out = 0.055
+    bore_fraction = 0.6
+    current_amp = 200.0
+    electrical_hz = 60.0
+
+    total_frames = frames_per_cycle * cycles
+    dt = 1.0 / electrical_hz / frames_per_cycle
+    omega = 2.0 * math.pi * electrical_hz
+
+    outer_polygon = build_circle(r_out, 256)
+    bore_polygon = build_circle(r_in, 192)
+
+    slot_outer_radius = min(r_out - 0.002, r_in + slot_depth)
+    slot_inner_radius = r_in
+
+    slot_definitions = [
+        ("A", +1.0, math.radians(0.0), "A_pos"),
+        ("B", -1.0, math.radians(60.0), "B_neg"),
+        ("C", +1.0, math.radians(120.0), "C_pos"),
+        ("A", -1.0, math.radians(180.0), "A_neg"),
+        ("B", +1.0, math.radians(240.0), "B_pos"),
+        ("C", -1.0, math.radians(300.0), "C_neg"),
+    ]
+
+    slot_polygons: List[List[List[float]]] = []
+    sources = []
+    for phase, orientation, angle, label in slot_definitions:
+        polygon = build_slot_polygon(angle, slot_inner_radius, slot_outer_radius, slot_width_deg)
+        slot_polygons.append(polygon)
+        sources.append(
+            {
+                "type": "current_region",
+                "id": label,
+                "phase": phase,
+                "orientation": orientation,
+                "vertices": polygon,
+                "I": 0.0,
+            }
+        )
+
+    regions: List[Dict[str, object]] = [
+        {"type": "uniform", "material": "air"},
+        {"type": "polygon", "material": "stator_steel", "vertices": outer_polygon},
+    ]
+    for polygon in slot_polygons:
+        regions.append({"type": "polygon", "material": "air", "vertices": polygon})
+    regions.append({"type": "polygon", "material": "air", "vertices": bore_polygon})
+
+    bore_probe_polygon = build_circle(r_in * bore_fraction, 96)
+
+    timeline = []
+    for frame_idx in range(total_frames):
+        time = frame_idx * dt
+        ia, ib, ic = compute_phase_currents(current_amp, omega, time)
+        timeline.append(
+            {
+                "t": time,
+                "phase_currents": {
+                    "A": ia,
+                    "B": ib,
+                    "C": ic,
+                },
+            }
+        )
+
+    scenario = {
+        "version": "0.2",
+        "units": "SI",
+        "domain": {"Lx": domain_size, "Ly": domain_size, "nx": nx, "ny": ny},
+        "boundary": {"type": "neumann"},
+        "materials": [
+            {"name": "air", "mu_r": 1.0},
+            {"name": "stator_steel", "mu_r": 400.0},
+        ],
+        "regions": regions,
+        "sources": sources,
+        "timeline": timeline,
+        "outputs": [
+            {
+                "type": "vtk_field_series",
+                "id": "series",
+                "dir": "outputs",
+                "basename": "three_phase_frame",
+                "quantities": ["B", "H"],
+            },
+            {
+                "type": "polyline_outlines",
+                "id": "outlines",
+                "path": "outputs/three_phase_outlines.vtp",
+            },
+            {
+                "type": "bore_avg_B",
+                "id": "bore",
+                "path": "outputs/bore_angle.csv",
+                "vertices": bore_probe_polygon,
+            },
+        ],
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(scenario, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=sorted(DEFAULT_PROFILES.keys()), default="ci")
+    parser.add_argument("--out", type=Path, required=True, help="Output scenario JSON path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    generate_scenario(args.profile, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/motorsim/io_vtk.cpp
+++ b/src/motorsim/io_vtk.cpp
@@ -349,5 +349,28 @@ void write_vtp_outlines(const std::string& path, const std::vector<VtkOutlineLoo
     }
 }
 
+void write_pvd_series(const std::string& path, const std::vector<PvdDataSet>& datasets) {
+    std::ofstream ofs(path);
+    if (!ofs.is_open()) {
+        throw std::runtime_error("Failed to open VTK series output: " + path);
+    }
+
+    const bool littleEndian = isLittleEndian();
+    ofs << "<?xml version=\"1.0\"?>\n";
+    ofs << "<VTKFile type=\"Collection\" version=\"0.1\" byte_order=\""
+        << (littleEndian ? "LittleEndian" : "BigEndian") << "\">\n";
+    ofs << "  <Collection>\n";
+    for (const auto& entry : datasets) {
+        ofs << "    <DataSet timestep=\"" << entry.time << "\" part=\"0\" file=\""
+            << entry.file << "\"/>\n";
+    }
+    ofs << "  </Collection>\n";
+    ofs << "</VTKFile>\n";
+    ofs.flush();
+    if (!ofs) {
+        throw std::runtime_error("Failed while writing VTK series output: " + path);
+    }
+}
+
 }  // namespace motorsim
 


### PR DESCRIPTION
## Summary
- add a three-phase stator scenario generator, animation helper, and rotation sanity check scripts
- extend the solver ingestion and CLI to support phase-labelled current regions, VTK series emission, and polyline outlines
- document the workflow and wire it into CI with artifact uploads

## Testing
- `cmake --build build -j`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e9af9f8b848331800420900f462e05