### PR TITLE
Add Streamlit GUI scaffolding with docs and tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,3 +3,9 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential cmake gdb python3 python3-pip git && \
     rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --no-cache-dir \
+    streamlit \
+    numpy \
+    matplotlib \
+    ezdxf

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ Python visualisers, and collecting the same artefacts that GitHub Actions
 uploads. When the script passes locally you can be confident the hosted CI will
 behave the same way.
 
+## Streamlit GUI
+
+The repository ships with a Streamlit-based front-end for quick experiments.
+Install the GUI dependencies (the devcontainer and `scripts/setup_env.sh`
+already do this) and launch the app from the repository root:
+
+```bash
+python3 -m pip install -r requirements-gui.txt  # skip if using the container
+streamlit run python/gui/app_streamlit.py
+```
+
+Forward port `8501` when using Codespaces/VS Code Remote and ensure
+`build/motor_sim` exists before running. The UI exposes file upload, solver
+controls, log streaming, a Stop button, and download links for generated CSVs.
+See `docs/user-guide/gui_streamlit.md` for a full walkthrough.
+
 `build/motor_sim` loads JSON scenarios that describe regions, currents, and
 optional permanent magnets. The automated regression suite lives in the
 `tests/` directory and spans the analytic \(\mu_0 I / (2\pi r)\) wire case, the

--- a/docs/developer-guide/dev-environment.md
+++ b/docs/developer-guide/dev-environment.md
@@ -79,6 +79,20 @@ For a live preview during edits, launch `mkdocs serve` from the repository root
 and open the reported `http://127.0.0.1:8000/` URL in a browser; the server
 reloads automatically when files change.
 
+### 1.4 Streamlit GUI
+
+For interactive experiments, launch the Streamlit UI from the repository root:
+
+```bash
+streamlit run python/gui/app_streamlit.py
+```
+
+Codespaces users should forward port `8501`. The app requires the simulator to
+be built (`build/motor_sim`) and streams solver logs directly into the browser.
+The sidebar lets you upload scenarios, tweak solver settings, and download the
+latest configuration. Refer to `docs/user-guide/gui_streamlit.md` for the full
+walkthrough.
+
 ## 2. VS Code configuration
 
 The repo ships with `.vscode/` settings tuned for the `CMake Tools` and `C/C++`

--- a/docs/developer-guide/implementation/streamlit-progress.md
+++ b/docs/developer-guide/implementation/streamlit-progress.md
@@ -1,0 +1,41 @@
+# Streamlit GUI Implementation Progress
+
+This log captures the major milestones while building the Streamlit-based GUI.
+It complements the solver progress log and helps future contributors understand
+what remains before feature parity with the CLI tools.
+
+## Checklist
+
+- [x] Add Streamlit, `numpy`, `matplotlib`, and `ezdxf` to the development
+      environment (`.devcontainer/Dockerfile`, `scripts/setup_env.sh`, and
+      `requirements-gui.txt`).
+- [x] Scaffold the `python/gui` package with `app_streamlit.py`, helper tests,
+      and agent notes.
+- [x] Implement sidebar controls (file upload, solver configuration, scenario
+      download) and main-panel placeholders (geometry preview, status, logs,
+      progress bar, and output downloads).
+- [x] Wire the Streamlit UI to `motor_sim` via `subprocess`, including live log
+      streaming and a Stop button backed by session state.
+- [x] Provide a headless `--test-run` mode for smoke testing and CI integration.
+- [x] Document usage in `docs/user-guide/gui_streamlit.md` and reference the
+      alternative Flask branch.
+- [x] Add unit tests covering scenario staging, metadata generation, process log
+      streaming, and the test hook.
+- [ ] Visual geometry previews and DXF-to-scenario conversion pipeline.
+- [ ] Richer progress reporting (parse residual percentages rather than counting
+      log lines).
+- [ ] In-app visualisation of solver outputs (e.g., field maps via matplotlib).
+
+## Notes
+
+- DXF uploads currently short-circuit after staging; once the geometry pipeline
+  is ready, replace the placeholder message with conversion to scenario JSON and
+  reuse the existing run loop.
+- The Stop button terminates `motor_sim` by sending `terminate()` and relaying a
+  log message. If the simulator adds a graceful shutdown flag, prefer that over
+  termination to avoid partial output files.
+- Output download links are built from the scenario JSON. Ensure new scenario
+  schemas continue to populate `outputs[*].path` so the GUI can locate files.
+- Keep long-running operations (mesh generation, solves) within the streaming
+  loop to preserve responsiveness—avoid blocking the Streamlit script without
+  emitting log messages.

--- a/docs/user-guide/gui_streamlit.md
+++ b/docs/user-guide/gui_streamlit.md
@@ -1,0 +1,103 @@
+# Web GUI (Streamlit) Usage
+
+The Streamlit interface provides a lightweight browser-based front-end for
+running `motor_sim` without leaving the development environment. It is designed
+for quick iteration: upload a scenario, tweak solver options, and watch the
+progress log update live as the solver runs.
+
+## Prerequisites
+
+The development container and setup script install the required Python
+dependencies (`streamlit`, `numpy`, `matplotlib`, and `ezdxf`). If you are
+working outside the container, install them manually:
+
+```bash
+python3 -m pip install -r requirements-gui.txt
+```
+
+Compile the simulator before launching the GUI:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+The GUI expects the `build/motor_sim` binary to be present.
+
+## Launching the app
+
+From the repository root run:
+
+```bash
+streamlit run python/gui/app_streamlit.py
+```
+
+Streamlit listens on port `8501` by default. In VS Code Remote or GitHub
+Codespaces forward that port to your browser. When the page loads you will see
+an idle progress bar, a placeholder geometry preview, and an empty log panel.
+
+## Sidebar controls
+
+The sidebar contains everything required to stage a simulation:
+
+- **File uploader** – Accepts JSON scenarios or raw DXF geometry. JSON files are
+  passed straight to the solver. DXF upload support is staged for future work;
+  the GUI records the file and surfaces a reminder that parsing is not yet
+  available.
+- **Solver configuration** – Choose between the SOR and CG solvers, set the
+  convergence tolerance, maximum iterations, and the progress sampling cadence.
+  These values are forwarded as CLI flags when the solver launches.
+- **Scenario download** – Press *Download Scenario JSON* to export the current
+  configuration (including solver options) as a JSON file. This is useful for
+  versioning or running the same configuration from the command line.
+- **Region selection note** – A short reminder marks the spot where future
+  multi-region controls will appear once DXF ingestion lands.
+
+## Main panel walkthrough
+
+1. **Geometry preview** – Indicates whether a scenario JSON or DXF file is in
+   use. Visualisation hooks are stubbed for now and will be populated once the
+   geometry pipeline is integrated.
+2. **Run/Stop buttons** – Use *Run Simulation* to start a solve. The button is
+   disabled while a simulation is running to prevent duplicate launches. The
+   *Stop Simulation* button sets a session flag that terminates the solver
+   process on the next log update.
+3. **Status & progress** – A live progress bar increments with each log line and
+   resets when runs complete or abort. Status text summarises the most recent
+   action (starting, stopping, completion, or failure).
+4. **Log panel** – Streams combined stdout/stderr from `motor_sim`. Messages are
+   appended as the solver runs so you can watch residuals and diagnostics in
+   real time.
+5. **Outputs** – After a successful run the GUI scans the scenario's `outputs`
+   section and renders download buttons for each file that exists on disk. This
+   is ideal for quickly grabbing CSVs for plotting.
+
+If the solver terminates early (either via the Stop button or due to an error)
+all state flags reset and the progress bar returns to zero. Errors surface in
+red above the log panel for quick diagnosis.
+
+## Limitations and tips
+
+- DXF support is intentionally minimal in this iteration. Uploads are preserved
+  for later conversion but are not yet passed through to the solver.
+- Ensure that the simulator has been built before launching the GUI. The app
+  reports a helpful error if `build/motor_sim` is missing.
+- Long-running simulations still stream logs, but Streamlit queues updates. If
+  you need higher fidelity residual history, also enable `--progress-history`
+  in your scenario and download the CSV afterwards.
+- The download buttons read files on each render; large artefacts should remain
+  outside of Git history in keeping with repository guidelines.
+
+## Alternate implementation
+
+A Flask-based prototype lives on the `feat/gui-flask` branch. Check out that
+branch if you would like to compare approaches:
+
+```bash
+git fetch origin
+git checkout feat/gui-flask
+```
+
+Switch back to the current Streamlit implementation with `git checkout main`
+(or the branch you are developing on). The Streamlit UI provides the simplest
+on-ramp for experimentation and is the recommended path going forward.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - Quickstart: quickstart.md
   - User Guide:
       - user-guide/running-simulations.md
+      - Web GUI (Streamlit): user-guide/gui_streamlit.md
       - Machines:
           - user-guide/machines/three-phase-stator.md
           - user-guide/machines/induction.md
@@ -99,6 +100,7 @@ nav:
       - Implementation:
           - developer-guide/implementation/status.md
           - developer-guide/implementation/progress.md
+          - developer-guide/implementation/streamlit-progress.md
           - developer-guide/implementation/validation-stages.md
           - developer-guide/implementation/solver-benchmarks.md
       - Math & Solver:

--- a/python/gui/AGENTS.md
+++ b/python/gui/AGENTS.md
@@ -1,0 +1,18 @@
+# GUI Module Agent Notes
+
+This package contains the Streamlit-based user interface for the simulator.
+
+- `app_streamlit.py` is the main entry point. Keep interactive logic in small,
+  testable helpers – functions at module scope should accept pure-Python data
+  so we can exercise them from `tests/test_gui_streamlit.py` without spinning up
+  a Streamlit runtime.
+- Stick to first-party Streamlit widgets. Avoid shipping compiled/bundled
+  JavaScript or large static assets; render plots dynamically instead.
+- Update `docs/user-guide/gui_streamlit.md` and developer notes when changing
+  user-visible behaviour. Extend automated tests as part of any behavioural
+  change.
+- Remember that long-running subprocess calls must stream logs back to the UI.
+  Use the helpers in this module to keep the interface responsive and honour
+  the Stop button semantics.
+- Do not commit binary artefacts (screenshots, renders, etc.). Generate them at
+  runtime if needed for documentation.

--- a/python/gui/__init__.py
+++ b/python/gui/__init__.py
@@ -1,0 +1,9 @@
+"""GUI package for Streamlit-based simulator controls."""
+
+from .app_streamlit import DEFAULT_SCENARIO_PATH, stage_scenario_file, build_downloadable_scenario
+
+__all__ = [
+    "DEFAULT_SCENARIO_PATH",
+    "stage_scenario_file",
+    "build_downloadable_scenario",
+]

--- a/python/gui/app_streamlit.py
+++ b/python/gui/app_streamlit.py
@@ -1,0 +1,459 @@
+"""Streamlit application for the 2D motor simulator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import streamlit as st
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCENARIO_PATH = REPO_ROOT / "inputs" / "two_wire_cancel.json"
+MOTOR_SIM_BINARY = REPO_ROOT / "build" / "motor_sim"
+
+
+def ensure_session_state() -> None:
+    """Initialise Streamlit session state defaults."""
+    state = st.session_state
+    state.setdefault("running", False)
+    state.setdefault("stop_requested", False)
+    state.setdefault("log_lines", [])
+    state.setdefault("progress", 0)
+    state.setdefault("status_message", "Idle.")
+    state.setdefault("available_outputs", [])
+    state.setdefault("last_scenario_text", "")
+
+
+def stage_scenario_file(
+    uploaded_file: Optional[object],
+    scratch_dir: Path,
+    default_scenario_path: Path = DEFAULT_SCENARIO_PATH,
+) -> tuple[Optional[Path], List[str]]:
+    """Persist the selected scenario or DXF file to a temporary location.
+
+    Parameters
+    ----------
+    uploaded_file:
+        The Streamlit ``UploadedFile`` (or a stub with ``name`` and ``getvalue``)
+        selected by the user. ``None`` selects the default bundled scenario.
+    scratch_dir:
+        Directory where the staged file should be written.
+    default_scenario_path:
+        Fallback JSON scenario bundled with the repository.
+
+    Returns
+    -------
+    tuple[Optional[Path], List[str]]
+        The path to a JSON scenario file (``None`` when the upload is a DXF) and
+        human-readable log messages describing the chosen path.
+    """
+
+    messages: List[str] = []
+
+    if uploaded_file is None:
+        destination = scratch_dir / default_scenario_path.name
+        destination.write_bytes(default_scenario_path.read_bytes())
+        messages.append(
+            f"Using bundled scenario: {default_scenario_path.relative_to(REPO_ROOT)}"
+        )
+        return destination, messages
+
+    name = getattr(uploaded_file, "name", "uploaded")
+    suffix = Path(name).suffix.lower()
+
+    try:
+        data = uploaded_file.getvalue()
+    except AttributeError as exc:  # pragma: no cover - defensive guard
+        raise TypeError("uploaded_file must expose a getvalue() method") from exc
+
+    destination = scratch_dir / Path(name).name
+    destination.write_bytes(data)
+
+    if suffix == ".json":
+        messages.append(f"Loaded scenario from uploaded JSON: {name}")
+        return destination, messages
+
+    if suffix == ".dxf":
+        messages.append(
+            "DXF parsing is not yet implemented. Upload recorded for future processing."
+        )
+        return None, messages
+
+    messages.append(f"Unsupported file type: {suffix or 'unknown'}")
+    return None, messages
+
+
+def build_downloadable_scenario(
+    base_json_text: str,
+    solver: str,
+    tolerance: float,
+    max_iters: int,
+) -> str:
+    """Augment the provided scenario JSON with UI metadata for download."""
+    try:
+        scenario = json.loads(base_json_text)
+    except json.JSONDecodeError:
+        scenario = {
+            "version": "0.2",
+            "metadata": {},
+        }
+
+    metadata = scenario.setdefault("metadata", {})
+    metadata["ui_defaults"] = {
+        "solver": solver,
+        "tolerance": tolerance,
+        "max_iters": max_iters,
+    }
+    return json.dumps(scenario, indent=2) + "\n"
+
+
+def collect_output_paths_from_scenario(scenario_text: str) -> List[Path]:
+    """Extract output file paths from a scenario JSON blob."""
+    try:
+        payload = json.loads(scenario_text)
+    except json.JSONDecodeError:
+        return []
+
+    results: List[Path] = []
+    for entry in payload.get("outputs", []):
+        if not isinstance(entry, dict):
+            continue
+        path_value = entry.get("path")
+        if not isinstance(path_value, str):
+            continue
+        path_obj = Path(path_value)
+        if not path_obj.is_absolute():
+            path_obj = (REPO_ROOT / path_obj).resolve()
+        results.append(path_obj)
+    return results
+
+
+def stream_process_output(
+    process: subprocess.Popen,
+    stop_checker: Callable[[], bool],
+    on_line: Callable[[str], None],
+    on_progress: Callable[[int], None],
+    idle_sleep: float = 0.1,
+) -> int:
+    """Stream logs from ``process`` while updating UI callbacks."""
+    progress_value = 0
+    try:
+        if process.stdout is None:
+            raise RuntimeError("Process must be created with stdout=PIPE")
+
+        while True:
+            line = process.stdout.readline()
+            if line:
+                clean_line = line.rstrip("\n")
+                on_line(clean_line)
+                progress_value = min(100, progress_value + 1)
+                on_progress(progress_value)
+                if stop_checker():
+                    on_line("Stop requested by user. Terminating simulation...")
+                    process.terminate()
+                    break
+            elif process.poll() is not None:
+                break
+            else:
+                if stop_checker():
+                    on_line("Stop requested by user. Terminating simulation...")
+                    process.terminate()
+                    break
+                time.sleep(idle_sleep)
+
+        return_code = process.wait()
+    finally:
+        if process.stdout is not None:
+            process.stdout.close()
+
+    return return_code
+
+
+def request_stop() -> None:
+    """Signal that the running simulation should halt."""
+    st.session_state.stop_requested = True
+
+
+def render_app() -> None:
+    """Render the Streamlit user interface."""
+    st.set_page_config(page_title="2D Motor Simulator GUI", layout="wide")
+    ensure_session_state()
+
+    st.title("2D Motor Simulator GUI")
+    st.markdown(
+        """
+        Upload a geometry or scenario file, tune solver controls, and launch the
+        `motor_sim` solver directly from your browser. The interface streams
+        solver logs, exposes quick download links, and captures the latest
+        scenario for reuse.
+        """
+    )
+
+    with st.sidebar:
+        st.header("Scenario Setup")
+        uploaded_file = st.file_uploader(
+            "Upload Geometry (DXF or JSON)",
+            type=["dxf", "json"],
+        )
+
+        solver_choice = st.selectbox("Solver", ["SOR", "CG"])
+        tolerance_value = st.number_input(
+            "Tolerance",
+            value=1e-6,
+            format="%e",
+        )
+        max_iters_value = st.number_input(
+            "Max Iterations",
+            value=40000,
+            step=1000,
+            min_value=1,
+        )
+        progress_every = st.number_input(
+            "Progress cadence (s)",
+            value=2.0,
+            step=0.5,
+            min_value=0.0,
+        )
+
+        # Placeholder for future region-selection controls.
+        st.caption(
+            "Region selection presets will appear here once multi-region geometries are supported."
+        )
+
+        if uploaded_file and uploaded_file.name.lower().endswith(".json"):
+            base_text = uploaded_file.getvalue().decode("utf-8")
+        else:
+            base_text = DEFAULT_SCENARIO_PATH.read_text()
+
+        scenario_download = build_downloadable_scenario(
+            base_text, solver_choice.lower(), float(tolerance_value), int(max_iters_value)
+        )
+        st.download_button(
+            "Download Scenario JSON",
+            data=scenario_download,
+            file_name="scenario.json",
+            mime="application/json",
+            help="Save the current settings as a reusable scenario file.",
+        )
+
+    geometry_placeholder = st.empty()
+    if uploaded_file:
+        if uploaded_file.name.lower().endswith(".dxf"):
+            geometry_placeholder.warning(
+                "DXF previews are not yet implemented. The file will be staged for future parsing."
+            )
+        else:
+            geometry_placeholder.info(
+                f"Ready to run scenario from {uploaded_file.name}. Visualization hooks coming soon."
+            )
+    else:
+        geometry_placeholder.info(
+            f"Using default scenario: {DEFAULT_SCENARIO_PATH.relative_to(REPO_ROOT)}"
+        )
+
+    controls_col, status_col = st.columns([1, 2])
+    with controls_col:
+        run_clicked = st.button("Run Simulation", disabled=st.session_state.running)
+    with status_col:
+        st.button(
+            "Stop Simulation",
+            disabled=not st.session_state.running,
+            on_click=request_stop,
+        )
+
+    progress_bar = st.progress(st.session_state.progress)
+    status_placeholder = st.empty()
+    status_placeholder.info(st.session_state.status_message)
+
+    st.subheader("Simulation Log")
+    log_placeholder = st.empty()
+    if st.session_state.log_lines:
+        log_placeholder.code("\n".join(st.session_state.log_lines[-200:]), language="text")
+    else:
+        log_placeholder.code("Awaiting simulation run...", language="text")
+
+    outputs_placeholder = st.container()
+    if st.session_state.available_outputs:
+        with outputs_placeholder:
+            st.subheader("Outputs")
+            for path in st.session_state.available_outputs:
+                label = path.name
+                if path.exists():
+                    st.download_button(
+                        label=f"Download {label}",
+                        data=path.read_bytes(),
+                        file_name=label,
+                        key=f"download-{label}",
+                    )
+                else:
+                    st.warning(f"Expected output missing: {path}")
+
+    if run_clicked:
+        if uploaded_file is None and not DEFAULT_SCENARIO_PATH.exists():
+            st.error("Default scenario missing. Please provide a scenario JSON to continue.")
+            return
+
+        st.session_state.running = True
+        st.session_state.stop_requested = False
+        st.session_state.log_lines = []
+        st.session_state.progress = 0
+        st.session_state.status_message = "Starting simulation..."
+        status_placeholder.info(st.session_state.status_message)
+        log_placeholder.code("Preparing scenario...", language="text")
+        progress_bar.progress(0)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scratch = Path(temp_dir)
+            try:
+                scenario_path, stage_messages = stage_scenario_file(uploaded_file, scratch)
+            except Exception as exc:  # pragma: no cover - defensive UI guard
+                st.session_state.running = False
+                st.session_state.status_message = f"Failed to stage scenario: {exc}"
+                status_placeholder.error(st.session_state.status_message)
+                return
+
+            for message in stage_messages:
+                st.session_state.log_lines.append(message)
+
+            if scenario_path is None:
+                st.session_state.status_message = stage_messages[-1] if stage_messages else "DXF handling unavailable."
+                status_placeholder.warning(st.session_state.status_message)
+                st.session_state.running = False
+                st.session_state.progress = 0
+                progress_bar.progress(0)
+                log_placeholder.code("\n".join(st.session_state.log_lines[-200:]), language="text")
+                return
+
+            scenario_text = scenario_path.read_text()
+            st.session_state.last_scenario_text = scenario_text
+
+            if not MOTOR_SIM_BINARY.exists():
+                st.session_state.status_message = (
+                    "motor_sim binary not found. Build the project (cmake --build build) before running the GUI."
+                )
+                status_placeholder.error(st.session_state.status_message)
+                st.session_state.running = False
+                st.session_state.progress = 0
+                progress_bar.progress(0)
+                return
+
+            cmd: List[str] = [
+                str(MOTOR_SIM_BINARY),
+                "--scenario",
+                str(scenario_path),
+                "--solve",
+                "--solver",
+                solver_choice.lower(),
+                "--tol",
+                f"{tolerance_value}",
+                "--max-iters",
+                str(int(max_iters_value)),
+            ]
+            if progress_every > 0:
+                cmd.extend(["--progress-every", f"{progress_every}"])
+
+            st.session_state.log_lines.append("Launching motor_sim...")
+            log_placeholder.code("\n".join(st.session_state.log_lines[-200:]), language="text")
+
+            try:
+                process = subprocess.Popen(
+                    cmd,
+                    cwd=str(REPO_ROOT),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                )
+            except FileNotFoundError as exc:
+                st.session_state.status_message = f"Failed to launch motor_sim: {exc}"
+                status_placeholder.error(st.session_state.status_message)
+                st.session_state.running = False
+                st.session_state.progress = 0
+                progress_bar.progress(0)
+                return
+
+            def log_callback(line: str) -> None:
+                st.session_state.log_lines.append(line)
+                log_placeholder.code("\n".join(st.session_state.log_lines[-200:]), language="text")
+
+            def progress_callback(value: int) -> None:
+                st.session_state.progress = value
+                progress_bar.progress(value)
+
+            def check_stop() -> bool:
+                return bool(st.session_state.stop_requested)
+
+            return_code = stream_process_output(process, check_stop, log_callback, progress_callback)
+
+            stop_was_requested = bool(st.session_state.stop_requested)
+            st.session_state.running = False
+            st.session_state.stop_requested = False
+
+            if return_code == 0 and not stop_was_requested:
+                st.session_state.status_message = "Simulation completed successfully."
+                progress_callback(100)
+            elif stop_was_requested:
+                st.session_state.status_message = "Simulation stopped by user."
+                st.session_state.progress = 0
+                progress_bar.progress(0)
+            else:
+                st.session_state.status_message = f"Simulation exited with code {return_code}."
+                st.session_state.progress = 0
+                progress_bar.progress(0)
+
+            status_placeholder.info(st.session_state.status_message)
+
+            if st.session_state.last_scenario_text:
+                st.session_state.available_outputs = collect_output_paths_from_scenario(
+                    st.session_state.last_scenario_text
+                )
+            else:
+                st.session_state.available_outputs = []
+
+            log_placeholder.code("\n".join(st.session_state.log_lines[-200:]), language="text")
+
+            outputs_placeholder.empty()
+            if st.session_state.available_outputs:
+                with outputs_placeholder:
+                    st.subheader("Outputs")
+                    for path in st.session_state.available_outputs:
+                        label = path.name
+                        if path.exists():
+                            st.download_button(
+                                label=f"Download {label}",
+                                data=path.read_bytes(),
+                                file_name=label,
+                                key=f"download-{label}",
+                            )
+                        else:
+                            st.warning(f"Expected output missing: {path}")
+
+    # Refresh status in case session state changed elsewhere.
+    status_placeholder.info(st.session_state.status_message)
+
+
+def _test_run() -> None:
+    """Headless test hook used by automated checks."""
+    print("Streamlit GUI test run starting...")
+    fake_lines = [
+        "Preparing solver...",
+        "Solving linear system...",
+        "Post-processing outputs...",
+        "Done.",
+    ]
+    for idx, line in enumerate(fake_lines, start=1):
+        print(f"[{idx}] {line}")
+        time.sleep(0.05)
+    print("Streamlit GUI test run completed successfully.")
+
+
+if __name__ == "__main__":
+    if "--test-run" in sys.argv:
+        _test_run()
+    else:
+        render_app()

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,0 +1,4 @@
+streamlit
+numpy
+matplotlib
+ezdxf

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 sudo apt-get update
 sudo apt-get install -y build-essential cmake gdb git python3 python3-pip
 
-pip3 install --user numpy matplotlib
+pip3 install --user numpy matplotlib streamlit ezdxf
 
 echo "Environment ready."

--- a/tests/test_gui_streamlit.py
+++ b/tests/test_gui_streamlit.py
@@ -1,0 +1,176 @@
+"""Unit tests for the Streamlit GUI helpers."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import List
+
+from python.gui import app_streamlit
+
+
+class DummyUpload:
+    def __init__(self, name: str, data: bytes) -> None:
+        self.name = name
+        self._data = data
+
+    def getvalue(self) -> bytes:
+        return self._data
+
+
+class DummyStdout:
+    def __init__(self, lines: List[str]) -> None:
+        self._lines = lines
+        self._index = 0
+        self.closed = False
+
+    def readline(self) -> str:
+        if self._index < len(self._lines):
+            line = self._lines[self._index]
+            self._index += 1
+            return line
+        return ""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class DummyProcess:
+    def __init__(self, lines: List[str], return_code: int = 0) -> None:
+        self.stdout = DummyStdout(lines)
+        self._return_code = return_code
+        self._terminated = False
+
+    def poll(self) -> int | None:
+        if self.stdout._index >= len(self.stdout._lines):
+            return self._return_code
+        return None
+
+    def wait(self) -> int:
+        return self._return_code
+
+    def terminate(self) -> None:
+        self._terminated = True
+
+    @property
+    def terminated(self) -> bool:
+        return self._terminated
+
+
+class StageScenarioTests(unittest.TestCase):
+    def test_stage_default_scenario(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path, messages = app_streamlit.stage_scenario_file(
+                uploaded_file=None,
+                scratch_dir=Path(tmpdir),
+            )
+            self.assertIsNotNone(path)
+            self.assertTrue(messages)
+            assert path is not None
+            self.assertTrue(path.exists())
+            self.assertEqual(
+                path.read_bytes(),
+                app_streamlit.DEFAULT_SCENARIO_PATH.read_bytes(),
+            )
+
+    def test_stage_json_upload(self) -> None:
+        payload = json.dumps({"version": "0.2", "metadata": {}}).encode("utf-8")
+        upload = DummyUpload("custom.json", payload)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path, messages = app_streamlit.stage_scenario_file(upload, Path(tmpdir))
+            self.assertIsNotNone(path)
+            self.assertIn("uploaded JSON", " ".join(messages))
+            self.assertEqual(path.read_bytes(), payload)
+
+    def test_stage_dxf_upload(self) -> None:
+        payload = b"0\nSECTION\nENDSEC\nEOF\n"
+        upload = DummyUpload("shape.dxf", payload)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path, messages = app_streamlit.stage_scenario_file(upload, Path(tmpdir))
+            self.assertIsNone(path)
+            self.assertTrue(any("DXF" in message for message in messages))
+
+
+class DownloadableScenarioTests(unittest.TestCase):
+    def test_build_downloadable_scenario_injects_metadata(self) -> None:
+        base = json.dumps({"version": "0.2", "metadata": {"foo": "bar"}})
+        rendered = app_streamlit.build_downloadable_scenario(base, "cg", 1e-6, 12345)
+        payload = json.loads(rendered)
+        self.assertIn("ui_defaults", payload["metadata"])
+        self.assertEqual(payload["metadata"]["ui_defaults"]["solver"], "cg")
+        self.assertEqual(payload["metadata"]["ui_defaults"]["max_iters"], 12345)
+
+    def test_build_downloadable_scenario_handles_invalid_json(self) -> None:
+        rendered = app_streamlit.build_downloadable_scenario("not json", "sor", 1e-5, 42)
+        payload = json.loads(rendered)
+        self.assertEqual(payload["metadata"]["ui_defaults"]["solver"], "sor")
+
+
+class StreamProcessTests(unittest.TestCase):
+    def test_stream_process_output_collects_logs(self) -> None:
+        process = DummyProcess(["line 1\n", "line 2\n"])
+        logs: List[str] = []
+        progress_updates: List[int] = []
+
+        def stop_checker() -> bool:
+            return False
+
+        exit_code = app_streamlit.stream_process_output(
+            process,
+            stop_checker,
+            logs.append,
+            progress_updates.append,
+            idle_sleep=0.0,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(logs, ["line 1", "line 2"])
+        self.assertTrue(progress_updates)
+        self.assertFalse(process.terminated)
+
+    def test_stream_process_output_honours_stop(self) -> None:
+        process = DummyProcess(["line 1\n", "line 2\n"])
+        logs: List[str] = []
+        progress_updates: List[int] = []
+
+        def stop_checker() -> bool:
+            return len(progress_updates) >= 1
+
+        app_streamlit.stream_process_output(
+            process,
+            stop_checker,
+            logs.append,
+            progress_updates.append,
+            idle_sleep=0.0,
+        )
+
+        self.assertTrue(process.terminated)
+        self.assertTrue(any("Stop requested" in line for line in logs))
+
+
+class OutputCollectionTests(unittest.TestCase):
+    def test_collect_output_paths_from_scenario(self) -> None:
+        payload = {
+            "outputs": [
+                {"path": "outputs/demo.csv"},
+                {"path": str(app_streamlit.REPO_ROOT / "outputs" / "absolute.csv")},
+                {"path": 123},
+            ]
+        }
+        paths = app_streamlit.collect_output_paths_from_scenario(json.dumps(payload))
+        self.assertEqual(len(paths), 2)
+        self.assertTrue(all(isinstance(p, Path) for p in paths))
+        self.assertTrue(all(p.is_absolute() for p in paths))
+
+
+class TestRunHook(unittest.TestCase):
+    def test_test_run_executes_without_error(self) -> None:
+        # The hook prints to stdout; we only need to ensure it completes.
+        app_streamlit._test_run()
+        # No assertion required—lack of exceptions is success.
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- install Streamlit and supporting GUI dependencies in the devcontainer setup and add a reusable requirements file
- scaffold the Streamlit-based GUI package with session-managed run controls, download helpers, and unit tests
- document the new interface, add implementation progress notes, and update MkDocs navigation

## Testing
- python -m unittest tests.test_gui_streamlit
- scripts/build_docs.sh --skip-install

------
https://chatgpt.com/codex/tasks/task_e_68f7f1bfe0908331aaf4bc4e457f9ac0