### PR TITLE
feat: add Flask-based GUI prototype

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,3 +3,6 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential cmake gdb python3 python3-pip git && \
     rm -rf /var/lib/apt/lists/*
+
+# Flask prototype dependencies plus plotting/dxf helpers reused by the GUI
+RUN pip3 install --no-cache-dir flask flask-cors numpy matplotlib ezdxf

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ comparison. Practical rules of thumb and sample measurements are documented in
 * `docs/math_and_solver.md` — physics background, discretisation, and test plan.
 * `docs/dev_environment.md` — IDE setup, VS Code workflow, and debugging tips.
 * `docs/solver_performance.md` — complexity discussion and benchmark reference.
+* `docs/user-guide/gui_flask.md` — lightweight Flask web GUI usage guide.
 * `CONTRIBUTING.md` — development workflow expectations, including the
   `scripts/run_ci_checks.sh` harness that mirrors GitHub Actions locally.
 

--- a/docs/developer-guide/implementation/flask-gui-progress.md
+++ b/docs/developer-guide/implementation/flask-gui-progress.md
@@ -1,0 +1,36 @@
+# Flask GUI Implementation Progress
+
+This log tracks the development of the Flask-based web prototype for `mag_sim`.
+It complements the existing implementation status and progress notes by focusing
+on the GUI-specific milestones.
+
+## Completed work
+
+- Provisioned the devcontainer with Flask, Flask-CORS, NumPy, Matplotlib, and
+  `ezdxf` so the GUI can reuse plotting or DXF parsing helpers when they become
+  available.
+- Established a Flask application (`python/gui/app_flask.py`) with:
+  - A background `SimulationManager` that keeps the `motor_sim` subprocess
+    isolated from request threads and streams stdout via server-sent events.
+  - Upload handling for scenario JSON files with validation and command-line
+    flag mapping for solver, tolerance, max iterations, and optional outputs.
+  - Download endpoints for the uploaded scenario and live log artefacts.
+- Added Bootstrap-backed templates that expose upload controls, progress bar,
+  log viewer, and download list with minimal JavaScript (EventSource + DOM
+  updates only).
+- Wrote unit tests that exercise upload flow, stop signalling, and the SSE
+  endpoint payloads without invoking the real solver binary.
+- Documented usage (`docs/user-guide/gui_flask.md`) and linked the new page into
+  the MkDocs navigation.
+
+## In-flight / next steps
+
+- DXF ingestion is still stubbed. Once the geometry-to-scenario converter is
+  ready we can replace the placeholder guard in `/upload` with real processing.
+- The progress parser currently looks for percentage tokens in stdout; refining
+  this to understand the solver's exact log format will improve the progress bar
+  fidelity.
+- Consider persisting additional solver outputs (e.g., field map CSVs) to the
+  downloads list once the CLI contract is finalised.
+- Harden long-running process management for multiple users (per-session queues
+  instead of global state) if the GUI graduates beyond a single-user demo.

--- a/docs/user-guide/gui_flask.md
+++ b/docs/user-guide/gui_flask.md
@@ -1,0 +1,66 @@
+# Web GUI (Flask)
+
+The Flask-based GUI provides a lightweight browser front-end for running
+`mag_sim` scenarios. It mirrors the functionality explored in the Streamlit
+prototype while staying close to the underlying command-line workflow.
+
+## Requirements
+
+- A built `motor_sim` executable in `./build/motor_sim`.
+- The devcontainer (or local virtual environment) must include Flask and its
+  lightweight companions. The repository's `.devcontainer/Dockerfile` installs
+  Flask, Flask-CORS, NumPy, Matplotlib, and `ezdxf` so the GUI has everything it
+  needs when launched inside Codespaces.
+
+## Starting the server
+
+From the repository root:
+
+```bash
+python -m python.gui.app_flask
+```
+
+The development server listens on `http://127.0.0.1:5000` by default. When
+running inside GitHub Codespaces or a similar environment, forward port 5000 to
+access the interface from your browser.
+
+Alternatively, set `FLASK_APP=python.gui.app_flask` and run `flask run` if you
+prefer Flask's CLI wrapper.
+
+## Using the interface
+
+1. Upload a scenario JSON file via the **Scenario file** input. (DXF uploads are
+   reserved for a future update and currently return a validation error.)
+2. Pick a solver (`cg` or `sor`), adjust the tolerance and maximum iteration
+   count if required, and optionally pass a value for `--outputs`.
+3. Click **Run simulation**. The form disables itself, the **Stop** button
+   becomes available, and a progress card appears.
+4. The server streams the solver's stdout via Server-Sent Events (SSE). The
+   progress bar reacts to any percentage tokens in the log, and the log panel
+   fills with the live output.
+5. When the run finishes, the log persists and a **Downloads** card appears with
+   links to the uploaded scenario and the captured log file. The log is useful
+   for sharing solver traces without leaving the browser.
+6. Click **Run simulation** again to process another scenario. Only one solve is
+   allowed at a time; the interface reports an error if you attempt to start a
+   second run before the first completes.
+
+Use the **Stop** button to request early termination. The server sends
+`terminate()` to the subprocess and the final log entry marks the stop request.
+Depending on solver state, expect a short delay while the child process exits.
+
+## Known limitations
+
+- DXF geometry ingestion is stubbed; use JSON scenarios generated via the
+  existing Python helpers until the converter is available.
+- The progress parser uses a simple percentage heuristic. If the solver log does
+  not emit percentage tokens the bar will stay at 0 % until the run completes.
+- The current prototype keeps global state and targets single-user usage. A
+  production deployment should move to per-session queues and authentication.
+
+## Related work
+
+A Streamlit-based GUI prototype lives on the `feat/gui-streamlit` branch. Both
+paths explore similar workflows; use this Flask version when you need explicit
+control over routing and templating, or switch branches to compare the
+Streamlit-powered experience.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - Quickstart: quickstart.md
   - User Guide:
       - user-guide/running-simulations.md
+      - Web GUI (Flask): user-guide/gui_flask.md
       - Machines:
           - user-guide/machines/three-phase-stator.md
           - user-guide/machines/induction.md
@@ -99,6 +100,7 @@ nav:
       - Implementation:
           - developer-guide/implementation/status.md
           - developer-guide/implementation/progress.md
+          - developer-guide/implementation/flask-gui-progress.md
           - developer-guide/implementation/validation-stages.md
           - developer-guide/implementation/solver-benchmarks.md
       - Math & Solver:

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,1 @@
+"""Helper modules for mag_sim (Python tooling and GUIs)."""

--- a/python/gui/.gitignore
+++ b/python/gui/.gitignore
@@ -1,0 +1,3 @@
+uploads/
+results/
+__pycache__/

--- a/python/gui/AGENTS.md
+++ b/python/gui/AGENTS.md
@@ -1,0 +1,14 @@
+# Flask GUI Agent Notes
+
+- This package hosts the Flask-based prototype web UI for `mag_sim`.
+- Keep browser dependencies minimal: prefer server-sent events (SSE) and
+  lightweight Bootstrap styling already included in the templates. Avoid adding
+  large frontend frameworks unless explicitly requested.
+- Reuse the existing `SimulationManager` helper when wiring new routes. Ensure
+  updates remain thread-safe and continue to enforce the single-simulation
+  constraint.
+- When modifying behaviour, update the user guide (`docs/user-guide/gui_flask.md`)
+  and extend `tests/test_gui_flask.py` so new code paths stay covered.
+- Runtime artefacts such as uploads and generated logs should stay out of the
+  repository. Use or extend the ignore rules in this directory if new folders
+  are introduced.

--- a/python/gui/__init__.py
+++ b/python/gui/__init__.py
@@ -1,0 +1,3 @@
+"""Flask GUI package for mag_sim."""
+
+from .app_flask import app  # noqa: F401

--- a/python/gui/app_flask.py
+++ b/python/gui/app_flask.py
@@ -1,0 +1,394 @@
+"""Flask application providing a lightweight web GUI for ``mag_sim``."""
+
+from __future__ import annotations
+
+import json
+import queue
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from flask import (
+    Flask,
+    Response,
+    abort,
+    redirect,
+    render_template,
+    request,
+    url_for,
+    send_file,
+)
+from werkzeug.utils import secure_filename
+
+
+ALLOWED_EXTENSIONS = {".json", ".dxf"}
+DEFAULT_SOLVER = "cg"
+DEFAULT_TOLERANCE = 1e-6
+DEFAULT_MAX_ITERS = 20000
+MAX_UPLOAD_SIZE_MB = 50
+
+
+class SimulationManager:
+    """Manage the lifecycle of a single background simulation process."""
+
+    def __init__(self, flask_app: Flask) -> None:
+        self._app = flask_app
+        self._lock = threading.Lock()
+        self._queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+        self._stop_requested = False
+        self._metadata: Dict[str, Any] = {}
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    @property
+    def queue(self) -> "queue.Queue[Dict[str, Any]]":
+        return self._queue
+
+    def start(
+        self,
+        command: List[str],
+        *,
+        scenario_path: Path,
+        log_path: Path,
+        extra_downloads: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        with self._lock:
+            if self._running:
+                raise RuntimeError("A simulation is already running.")
+            self._drain_queue_locked()
+            self._running = True
+            self._stop_requested = False
+            self._metadata = {
+                "scenario_path": scenario_path,
+                "log_path": log_path,
+                "extra_downloads": extra_downloads or [],
+            }
+            self._queue.put({
+                "started": True,
+                "message": "Simulation launched.",
+                "progress": 0,
+            })
+            thread = threading.Thread(
+                target=self._run_process, args=(command,), daemon=True
+            )
+            self._thread = thread
+            thread.start()
+
+    def stop(self) -> bool:
+        with self._lock:
+            if self._process is None or not self._running:
+                return False
+            self._stop_requested = True
+            self._queue.put({"message": "Termination requested…", "warning": True})
+            try:
+                self._process.terminate()
+            except OSError:
+                # Process already gone.
+                pass
+            return True
+
+    def reset(self) -> None:
+        """Test helper to clear internal state."""
+
+        with self._lock:
+            self._drain_queue_locked()
+            self._process = None
+            self._thread = None
+            self._running = False
+            self._stop_requested = False
+            self._metadata = {}
+
+    def _drain_queue_locked(self) -> None:
+        while True:
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+
+    def _run_process(self, command: List[str]) -> None:
+        log_path: Path = self._metadata["log_path"]
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        scenario_path: Path = self._metadata.get("scenario_path", log_path)
+
+        success = False
+        message = "Simulation did not start."
+
+        try:
+            with log_path.open("w", encoding="utf-8") as log_file:
+                try:
+                    process = subprocess.Popen(
+                        command,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        bufsize=1,
+                    )
+                except FileNotFoundError:
+                    message = (
+                        "Unable to start motor_sim; build the project before running the GUI."
+                    )
+                    self._queue.put({"message": message, "error": True})
+                    return
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    message = f"Failed to launch simulation: {exc}"
+                    self._queue.put({"message": message, "error": True})
+                    return
+
+                with self._lock:
+                    self._process = process
+
+                assert process.stdout is not None
+                for raw_line in process.stdout:
+                    line = raw_line.rstrip()
+                    log_file.write(line + "\n")
+                    log_file.flush()
+                    event: Dict[str, Any] = {"message": line}
+                    progress = _extract_progress(line)
+                    if progress is not None:
+                        event["progress"] = progress
+                    self._queue.put(event)
+
+                return_code = process.wait()
+                success = return_code == 0 and not self._stop_requested
+                if self._stop_requested and return_code != 0:
+                    # Some environments report 143 when terminate() is used; normalise.
+                    success = False
+
+                if self._stop_requested:
+                    message = "Simulation stopped by user."
+                elif success:
+                    message = "Simulation complete."
+                else:
+                    message = f"Simulation exited with code {return_code}."
+        finally:
+            with self._lock:
+                self._running = False
+                self._process = None
+            self._emit_completion(success=success, message=message, scenario_path=scenario_path)
+
+    def _emit_completion(self, *, success: bool, message: str, scenario_path: Path) -> None:
+        downloads = []
+        log_path: Optional[Path] = self._metadata.get("log_path")
+        if scenario_path and scenario_path.exists():
+            downloads.append(
+                {
+                    "category": "scenario",
+                    "filename": scenario_path.name,
+                    "label": "Uploaded scenario",
+                }
+            )
+        if log_path and Path(log_path).exists():
+            downloads.append(
+                {
+                    "category": "log",
+                    "filename": Path(log_path).name,
+                    "label": "Simulation log",
+                }
+            )
+        for extra in self._metadata.get("extra_downloads", []):
+            path = Path(extra.get("path"))
+            if not path.exists():
+                continue
+            downloads.append(
+                {
+                    "category": extra.get("category", "result"),
+                    "filename": path.name,
+                    "label": extra.get("label", path.name),
+                }
+            )
+
+        event: Dict[str, Any] = {"complete": True, "message": message, "success": success}
+        if success:
+            event["progress"] = 100
+        if self._stop_requested:
+            event["stopped"] = True
+        if downloads:
+            event["downloads"] = downloads
+
+        self._queue.put(event)
+        self._stop_requested = False
+
+
+def _extract_progress(line: str) -> Optional[int]:
+    for token in line.replace("%", " % ").split():
+        if token.endswith("%"):
+            token = token[:-1]
+        try:
+            value = float(token)
+        except ValueError:
+            continue
+        if 0 <= value <= 100:
+            return int(value)
+    return None
+
+
+BASE_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = BASE_DIR / "templates"
+STATIC_DIR = BASE_DIR / "static"
+
+app = Flask(__name__, template_folder=str(TEMPLATE_DIR), static_folder=str(STATIC_DIR))
+app.config.update(
+    UPLOAD_FOLDER=str(BASE_DIR / "uploads"),
+    RESULTS_FOLDER=str(BASE_DIR / "results"),
+    MAX_CONTENT_LENGTH=MAX_UPLOAD_SIZE_MB * 1024 * 1024,
+    JSON_SORT_KEYS=False,
+)
+
+Path(app.config["UPLOAD_FOLDER"]).mkdir(parents=True, exist_ok=True)
+Path(app.config["RESULTS_FOLDER"]).mkdir(parents=True, exist_ok=True)
+
+manager = SimulationManager(app)
+
+
+def allowed_file(filename: str) -> bool:
+    return Path(filename).suffix.lower() in ALLOWED_EXTENSIONS
+
+
+@app.get("/")
+def index() -> str:
+    error = request.args.get("error")
+    return render_template(
+        "index.html",
+        running=manager.is_running,
+        error=error,
+        default_solver=DEFAULT_SOLVER,
+        default_tolerance=DEFAULT_TOLERANCE,
+        default_max_iters=DEFAULT_MAX_ITERS,
+    )
+
+
+@app.post("/upload")
+def upload() -> Response:
+    if manager.is_running:
+        return redirect(url_for("index", error="A simulation is already running."))
+
+    geometry = request.files.get("geometry_file")
+    if geometry is None or geometry.filename == "":
+        return redirect(url_for("index", error="Select a scenario JSON before running."))
+
+    if not allowed_file(geometry.filename):
+        return redirect(url_for("index", error="Unsupported file type. Use JSON scenarios."))
+
+    solver = (request.form.get("solver") or DEFAULT_SOLVER).lower()
+    if solver not in {"cg", "sor"}:
+        return redirect(url_for("index", error="Solver must be either CG or SOR."))
+
+    tol_raw = request.form.get("tol", str(DEFAULT_TOLERANCE))
+    try:
+        tolerance = float(tol_raw)
+    except ValueError:
+        return redirect(url_for("index", error="Tolerance must be numeric."))
+
+    max_iters_raw = request.form.get("max_iters", str(DEFAULT_MAX_ITERS))
+    try:
+        max_iters = int(max_iters_raw)
+    except ValueError:
+        return redirect(url_for("index", error="Max iterations must be an integer."))
+
+    outputs_value = (request.form.get("outputs") or "").strip()
+
+    suffix = Path(geometry.filename).suffix.lower()
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    safe_name = secure_filename(geometry.filename) or f"scenario_{timestamp}{suffix}"
+    scenario_path = Path(app.config["UPLOAD_FOLDER"]) / f"{timestamp}_{safe_name}"
+
+    if suffix == ".json":
+        scenario_path.parent.mkdir(parents=True, exist_ok=True)
+        geometry.save(scenario_path)
+        try:
+            json.loads(scenario_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            scenario_path.unlink(missing_ok=True)
+            return redirect(url_for("index", error="Uploaded JSON is invalid."))
+    else:
+        # DXF support is not yet implemented for the Flask prototype.
+        return redirect(url_for("index", error="DXF uploads are not supported yet."))
+
+    command = [
+        "./build/motor_sim",
+        "--scenario",
+        str(scenario_path),
+        "--solver",
+        solver,
+        "--tol",
+        str(tolerance),
+        "--max-iters",
+        str(max_iters),
+        "--solve",
+    ]
+
+    if outputs_value:
+        command.extend(["--outputs", outputs_value])
+
+    log_path = Path(app.config["RESULTS_FOLDER"]) / f"simulation_{timestamp}.log"
+
+    try:
+        manager.start(
+            command,
+            scenario_path=scenario_path,
+            log_path=log_path,
+        )
+    except RuntimeError as exc:
+        return redirect(url_for("index", error=str(exc)))
+
+    return redirect(url_for("index"))
+
+
+@app.post("/stop")
+def stop() -> Response:
+    stopped = manager.stop()
+    status_code = 202 if stopped else 200
+    return ("", status_code)
+
+
+@app.get("/progress")
+def stream_progress() -> Response:
+    def event_stream() -> Any:
+        while True:
+            try:
+                payload = manager.queue.get(timeout=1.0)
+            except queue.Empty:
+                yield ": heartbeat\n\n"
+                continue
+
+            yield f"data: {json.dumps(payload)}\n\n"
+            if payload.get("complete"):
+                break
+
+    return Response(event_stream(), mimetype="text/event-stream")
+
+
+@app.get("/download")
+def download() -> Response:
+    category = request.args.get("category")
+    filename = request.args.get("filename")
+    if not category or not filename:
+        abort(400)
+
+    safe_name = secure_filename(filename)
+    if not safe_name:
+        abort(400)
+
+    if category == "scenario":
+        base_dir = Path(app.config["UPLOAD_FOLDER"])
+    elif category in {"log", "result"}:
+        base_dir = Path(app.config["RESULTS_FOLDER"])
+    else:
+        abort(404)
+
+    file_path = base_dir / safe_name
+    if not file_path.exists():
+        abort(404)
+
+    return send_file(file_path, as_attachment=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/python/gui/templates/base.html
+++ b/python/gui/templates/base.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>mag_sim Flask GUI</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    >
+    {% block head %}{% endblock %}
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">mag_sim GUI</a>
+      </div>
+    </nav>
+    <main class="container mb-5">
+      {% block content %}{% endblock %}
+    </main>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/python/gui/templates/index.html
+++ b/python/gui/templates/index.html
@@ -1,0 +1,175 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-lg-8">
+      <h1 class="mb-3">Run a Simulation</h1>
+      <p class="text-muted">Upload a scenario JSON, select solver options, and monitor progress in real time.</p>
+      {% if error %}
+        <div class="alert alert-danger" role="alert">
+          {{ error }}
+        </div>
+      {% endif %}
+      <form id="run-form" class="card card-body mb-3" method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data">
+        <div class="mb-3">
+          <label class="form-label" for="geometry-file">Scenario file (JSON)</label>
+          <input class="form-control" type="file" id="geometry-file" name="geometry_file" accept=".json,.dxf" required>
+          <div class="form-text">DXF uploads are reserved for a future update; please use JSON scenarios for now.</div>
+        </div>
+        <div class="row g-3">
+          <div class="col-md-4">
+            <label class="form-label" for="solver">Solver</label>
+            <select class="form-select" id="solver" name="solver">
+              <option value="cg" {% if default_solver == 'cg' %}selected{% endif %}>Conjugate Gradient (CG)</option>
+              <option value="sor" {% if default_solver == 'sor' %}selected{% endif %}>Successive Over-Relaxation (SOR)</option>
+            </select>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label" for="tol">Tolerance</label>
+            <input class="form-control" type="number" step="any" id="tol" name="tol" value="{{ default_tolerance }}" required>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label" for="max-iters">Max iterations</label>
+            <input class="form-control" type="number" id="max-iters" name="max_iters" value="{{ default_max_iters }}" min="1" required>
+          </div>
+        </div>
+        <div class="mb-3 mt-3">
+          <label class="form-label" for="outputs">Outputs (optional)</label>
+          <input class="form-control" type="text" id="outputs" name="outputs" placeholder="field_map">
+          <div class="form-text">Pass through to <code>motor_sim --outputs</code>; leave blank to use the solver default.</div>
+        </div>
+        <div class="d-flex gap-2">
+          <button id="run-btn" class="btn btn-primary" type="submit" {% if running %}disabled{% endif %}>Run simulation</button>
+          <button id="stop-btn" class="btn btn-warning" type="button" {% if not running %}disabled{% endif %}>Stop</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div id="progress-container" class="card card-body mb-3" style="display: none;">
+    <h2 class="h5">Progress</h2>
+    <div class="progress" style="height: 24px;">
+      <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;">0%</div>
+    </div>
+  </div>
+  <div id="log-container" class="card card-body mb-3" style="display: none;">
+    <h2 class="h5">Solver log</h2>
+    <pre id="log-area" class="bg-dark text-white p-3" style="max-height: 320px; overflow-y: auto;"></pre>
+  </div>
+  <div id="results" class="card card-body" style="display: none;">
+    <h2 class="h5">Downloads</h2>
+    <ul id="results-list" class="list-group list-group-flush"></ul>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const runForm = document.getElementById("run-form");
+      const runBtn = document.getElementById("run-btn");
+      const stopBtn = document.getElementById("stop-btn");
+      const progressContainer = document.getElementById("progress-container");
+      const progressBar = document.getElementById("progress-bar");
+      const logContainer = document.getElementById("log-container");
+      const logArea = document.getElementById("log-area");
+      const resultsContainer = document.getElementById("results");
+      const resultsList = document.getElementById("results-list");
+      const downloadBase = "{{ url_for('download') }}";
+      const isRunning = {{ 'true' if running else 'false' }};
+
+      if (isRunning) {
+        progressContainer.style.display = 'block';
+        logContainer.style.display = 'block';
+        runBtn.disabled = true;
+        stopBtn.disabled = false;
+      }
+
+      if (runForm) {
+        runForm.addEventListener("submit", function () {
+          runBtn.disabled = true;
+          stopBtn.disabled = false;
+          progressContainer.style.display = 'block';
+          logContainer.style.display = 'block';
+          resultsContainer.style.display = 'none';
+          resultsList.innerHTML = '';
+          logArea.textContent = '';
+          progressBar.classList.remove('bg-danger', 'bg-success');
+          progressBar.style.width = '0%';
+          progressBar.textContent = '0%';
+        });
+      }
+
+      stopBtn.addEventListener("click", function (event) {
+        event.preventDefault();
+        fetch("{{ url_for('stop') }}", { method: "POST" });
+      });
+
+      const source = new EventSource("{{ url_for('stream_progress') }}");
+      source.onmessage = function (event) {
+        if (!event.data) {
+          return;
+        }
+
+        let payload;
+        try {
+          payload = JSON.parse(event.data);
+        } catch (err) {
+          return;
+        }
+
+        if (payload.started) {
+          progressContainer.style.display = 'block';
+          logContainer.style.display = 'block';
+          stopBtn.disabled = false;
+        }
+
+        if (typeof payload.progress === 'number') {
+          const pct = Math.max(0, Math.min(100, payload.progress));
+          progressBar.style.width = pct + '%';
+          progressBar.textContent = pct + '%';
+        }
+
+        if (payload.message) {
+          const needsNewline = logArea.textContent.length > 0;
+          logArea.textContent += (needsNewline ? '\n' : '') + payload.message;
+          logArea.scrollTop = logArea.scrollHeight;
+        }
+
+        if (payload.error) {
+          progressBar.classList.add('bg-danger');
+        }
+
+        if (payload.complete) {
+          runBtn.disabled = false;
+          stopBtn.disabled = true;
+          if (payload.success) {
+            progressBar.classList.remove('bg-danger');
+            progressBar.classList.add('bg-success');
+            progressBar.style.width = '100%';
+            progressBar.textContent = '100%';
+          }
+
+          if (Array.isArray(payload.downloads) && payload.downloads.length > 0) {
+            resultsContainer.style.display = 'block';
+            resultsList.innerHTML = '';
+            payload.downloads.forEach(function (item) {
+              if (!item.filename || !item.category) {
+                return;
+              }
+              const url = new URL(downloadBase, window.location.origin);
+              url.searchParams.set('category', item.category);
+              url.searchParams.set('filename', item.filename);
+
+              const entry = document.createElement('li');
+              entry.className = 'list-group-item';
+              const link = document.createElement('a');
+              link.href = url.toString();
+              link.textContent = item.label || item.filename;
+              entry.appendChild(link);
+              resultsList.appendChild(entry);
+            });
+          }
+        }
+      };
+    });
+  </script>
+{% endblock %}

--- a/tests/test_gui_flask.py
+++ b/tests/test_gui_flask.py
@@ -1,0 +1,123 @@
+import io
+import json
+import queue
+import time
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from python.gui import app_flask
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    results = tmp_path / "results"
+    uploads.mkdir()
+    results.mkdir()
+    app_flask.app.config["UPLOAD_FOLDER"] = str(uploads)
+    app_flask.app.config["RESULTS_FOLDER"] = str(results)
+    app_flask.manager.reset()
+    yield
+    app_flask.manager.reset()
+
+
+@pytest.fixture
+def client():
+    with app_flask.app.test_client() as test_client:
+        yield test_client
+
+
+def test_upload_starts_simulation(monkeypatch, client):
+    popen_calls: List[List[str]] = []
+
+    class DummyProcess:
+        def __init__(self) -> None:
+            self.stdout = io.StringIO("10%\nFinished\n")
+            self.returncode = 0
+            self.terminated = False
+
+        def wait(self) -> int:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.terminated = True
+            self.returncode = 143
+
+    def fake_popen(cmd, **kwargs):  # noqa: ANN001 - signature mirrors subprocess
+        popen_calls.append(cmd)
+        return DummyProcess()
+
+    monkeypatch.setattr(app_flask.subprocess, "Popen", fake_popen)
+
+    payload = json.dumps({"version": "0.1"}).encode("utf-8")
+    response = client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(payload), "test.json"),
+            "solver": "cg",
+            "tol": "1e-6",
+            "max_iters": "5",
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 302
+
+    deadline = time.time() + 1
+    while time.time() < deadline and not popen_calls:
+        time.sleep(0.01)
+
+    assert popen_calls, "subprocess.Popen should be invoked"
+
+    events = []
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        try:
+            item = app_flask.manager.queue.get(timeout=0.1)
+            events.append(item)
+            if item.get("complete"):
+                break
+        except queue.Empty:
+            pass
+
+    assert any(evt.get("started") for evt in events)
+    assert any(evt.get("complete") for evt in events)
+    assert not app_flask.manager.is_running
+
+
+def test_stop_route_terminates_process(client):
+    class DummyProcess:
+        def __init__(self) -> None:
+            self.terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+    dummy = DummyProcess()
+    app_flask.manager.reset()
+    app_flask.manager._process = dummy  # type: ignore[attr-defined]
+    app_flask.manager._running = True  # type: ignore[attr-defined]
+
+    response = client.post("/stop")
+    assert response.status_code == 202
+    assert dummy.terminated
+
+    message = app_flask.manager.queue.get_nowait()
+    assert "Termination requested" in message["message"]
+
+
+def test_progress_stream_emits_payloads(client):
+    app_flask.manager.reset()
+    app_flask.manager.queue.put({"message": "hello"})
+    app_flask.manager.queue.put({"complete": True, "message": "done"})
+
+    response = client.get("/progress")
+    body = b"".join(response.response)
+
+    assert b"hello" in body
+    assert b"done" in body


### PR DESCRIPTION
## Summary
- add a Flask-backed GUI with SSE streaming, scenario uploads, and download links
- provide Bootstrap templates, agent notes, and documentation for running the Flask interface
- extend the devcontainer dependencies and add pytest coverage for the new routes

## Testing
- pytest tests/test_gui_flask.py

------
https://chatgpt.com/codex/tasks/task_e_68f7f241a35483319f9713a747afc2ee