### PR TITLE
Add Stage 1 web GUI with previews and visualization controls

### DIFF
--- a/docs/developer-guide/implementation/AGENTS.md
+++ b/docs/developer-guide/implementation/AGENTS.md
@@ -1,0 +1,14 @@
+# Implementation Progress Docs Notes
+
+- This folder hosts running logs that track implementation efforts for major
+  epics (solver, GUI, etc.). Keep entries factual and date-agnostic so the
+  narrative remains evergreen.
+- When you land new capabilities, add concise bullets under the relevant
+  sections rather than rewriting history; older entries provide context for
+  future contributors.
+- If you introduce a new epic, create a sibling progress file and reference it
+  from the MkDocs navigation (`mkdocs.yml`).
+- Tests or code changes that the documentation references should be cited with
+  file paths or module names where possible.
+- Avoid embedding binary artefacts or screenshots here—link to reproducible
+  commands or test cases instead.

--- a/docs/developer-guide/implementation/flask-gui-progress.md
+++ b/docs/developer-guide/implementation/flask-gui-progress.md
@@ -22,6 +22,15 @@ on the GUI-specific milestones.
   endpoint payloads without invoking the real solver binary.
 - Documented usage (`docs/user-guide/gui_flask.md`) and linked the new page into
   the MkDocs navigation.
+- **Stage 1 UI overhaul**:
+  - Split the main page into dedicated geometry, control, progress, downloads,
+    and visualisation panels with placeholders for future DXF/animation work.
+  - Added geometry preview rendering on demand plus live in-process and final
+    field-map visualisation streamed via SSE.
+  - Introduced configurable plotting controls (vector scaling, density,
+    overlays, logarithmic modes) that regenerate Matplotlib renders on request.
+  - Expanded automated coverage for preview flows, solver output detection, and
+    the visualisation endpoint to keep regression protection high.
 
 ## In-flight / next steps
 
@@ -30,7 +39,9 @@ on the GUI-specific milestones.
 - The progress parser currently looks for percentage tokens in stdout; refining
   this to understand the solver's exact log format will improve the progress bar
   fidelity.
-- Consider persisting additional solver outputs (e.g., field map CSVs) to the
-  downloads list once the CLI contract is finalised.
+- Surface more solver artefacts (line probes, streamlines) alongside field maps
+  once those exporters are exercised in real scenarios.
 - Harden long-running process management for multiple users (per-session queues
   instead of global state) if the GUI graduates beyond a single-user demo.
+- Add screenshot-driven regression tests for the Bootstrap layout when we wire
+  up a lightweight browser harness.

--- a/python/gui/AGENTS.md
+++ b/python/gui/AGENTS.md
@@ -7,6 +7,10 @@
 - Reuse the existing `SimulationManager` helper when wiring new routes. Ensure
   updates remain thread-safe and continue to enforce the single-simulation
   constraint.
+- Stage 1 of the GUI overhaul introduced geometry previews, live field-map
+  visualisation, and the `/visualization.png` customisation endpoint. Any
+  follow-up work should keep those panels functional and expand tests when
+  touching related code.
 - When modifying behaviour, update the user guide (`docs/user-guide/gui_flask.md`)
   and extend `tests/test_gui_flask.py` so new code paths stay covered.
 - Runtime artefacts such as uploads and generated logs should stay out of the

--- a/python/gui/app_flask.py
+++ b/python/gui/app_flask.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 import queue
+import re
 import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from flask import (
     Flask,
@@ -17,10 +18,16 @@ from flask import (
     redirect,
     render_template,
     request,
-    url_for,
     send_file,
+    url_for,
 )
 from werkzeug.utils import secure_filename
+
+from python.gui.render import (
+    DEFAULT_LOG_FLOOR,
+    render_field_map_image,
+    render_geometry_preview,
+)
 
 
 ALLOWED_EXTENSIONS = {".json", ".dxf"}
@@ -28,6 +35,13 @@ DEFAULT_SOLVER = "cg"
 DEFAULT_TOLERANCE = 1e-6
 DEFAULT_MAX_ITERS = 20000
 MAX_UPLOAD_SIZE_MB = 50
+DEFAULT_VECTOR_MODE = "linear"
+DEFAULT_COLOR_SCALE = "linear"
+DEFAULT_QUIVER_SKIP = 4
+DEFAULT_STREAMLINES = False
+FIELD_MAP_REGEX = re.compile(
+    r"Frame\\s+(?P<frame>\\d+):\\s+wrote\\s+field_map\\s+'(?P<id>[^']+)'\\s+to\\s+(?P<path>.+)"
+)
 
 
 class SimulationManager:
@@ -42,6 +56,7 @@ class SimulationManager:
         self._running = False
         self._stop_requested = False
         self._metadata: Dict[str, Any] = {}
+        self._last_result: Dict[str, Any] = {}
 
     @property
     def is_running(self) -> bool:
@@ -51,6 +66,10 @@ class SimulationManager:
     def queue(self) -> "queue.Queue[Dict[str, Any]]":
         return self._queue
 
+    def get_last_result(self) -> Dict[str, Any]:
+        with self._lock:
+            return dict(self._last_result)
+
     def start(
         self,
         command: List[str],
@@ -58,6 +77,7 @@ class SimulationManager:
         scenario_path: Path,
         log_path: Path,
         extra_downloads: Optional[List[Dict[str, Any]]] = None,
+        field_outputs: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
         with self._lock:
             if self._running:
@@ -69,6 +89,8 @@ class SimulationManager:
                 "scenario_path": scenario_path,
                 "log_path": log_path,
                 "extra_downloads": extra_downloads or [],
+                "field_outputs": field_outputs or [],
+                "processed_field_maps": set(),
             }
             self._queue.put({
                 "started": True,
@@ -104,6 +126,7 @@ class SimulationManager:
             self._running = False
             self._stop_requested = False
             self._metadata = {}
+            self._last_result = {}
 
     def _drain_queue_locked(self) -> None:
         while True:
@@ -111,6 +134,79 @@ class SimulationManager:
                 self._queue.get_nowait()
             except queue.Empty:
                 break
+
+    def _handle_field_map_event(self, *, frame: Optional[int], field_id: str, path_str: str) -> None:
+        scenario_path: Optional[Path] = self._metadata.get("scenario_path")
+        if scenario_path is None or not scenario_path.exists():
+            return
+
+        output_path = Path(path_str.strip())
+        if not output_path.is_absolute():
+            output_path = scenario_path.parent / output_path
+
+        if not output_path.exists():
+            return
+
+        with self._lock:
+            processed: Set[Path] = self._metadata.setdefault("processed_field_maps", set())
+            if output_path in processed:
+                return
+            processed.add(output_path)
+
+        results_dir = Path(self._app.config["RESULTS_FOLDER"])
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        frame_suffix = f"_frame{frame}" if frame is not None else ""
+        filename = f"field_progress_{timestamp}{frame_suffix}.png"
+        image_path = results_dir / filename
+
+        try:
+            render_field_map_image(
+                scenario_path,
+                output_path,
+                output_path=image_path,
+                vector_mode=DEFAULT_VECTOR_MODE,
+                quiver_skip=DEFAULT_QUIVER_SKIP,
+                color_scale=DEFAULT_COLOR_SCALE,
+                draw_boundaries=True,
+                streamlines=DEFAULT_STREAMLINES,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self._queue.put({
+                "message": f"Failed to render field map '{field_id}': {exc}",
+                "warning": True,
+            })
+            return
+
+        with self._lock:
+            self._metadata["latest_field_map"] = output_path
+            self._metadata["latest_image"] = image_path
+
+        caption = f"Frame {frame} field map" if frame is not None else f"Field map '{field_id}'"
+        self._queue.put(
+            {
+                "visualization": {
+                    "image": f"/result-image/{image_path.name}",
+                    "caption": caption,
+                }
+            }
+        )
+
+    def _candidate_field_maps(self) -> List[Path]:
+        scenario_path: Optional[Path] = self._metadata.get("scenario_path")
+        scenario_dir = scenario_path.parent if scenario_path else None
+        candidates: List[Path] = []
+        latest = self._metadata.get("latest_field_map")
+        if isinstance(latest, Path):
+            candidates.append(latest)
+        for entry in self._metadata.get("field_outputs", []):
+            path_value = entry.get("path")
+            if not path_value:
+                continue
+            path = Path(path_value)
+            if not path.is_absolute() and scenario_dir is not None:
+                path = scenario_dir / path
+            candidates.append(path)
+        return candidates
 
     def _run_process(self, command: List[str]) -> None:
         log_path: Path = self._metadata["log_path"]
@@ -154,6 +250,18 @@ class SimulationManager:
                     if progress is not None:
                         event["progress"] = progress
                     self._queue.put(event)
+
+                    match = FIELD_MAP_REGEX.match(line)
+                    if match:
+                        frame_value = match.group("frame")
+                        frame = int(frame_value) if frame_value is not None else None
+                        field_id = match.group("id")
+                        path_str = match.group("path")
+                        self._handle_field_map_event(
+                            frame=frame,
+                            field_id=field_id,
+                            path_str=path_str,
+                        )
 
                 return_code = process.wait()
                 success = return_code == 0 and not self._stop_requested
@@ -204,6 +312,67 @@ class SimulationManager:
                 }
             )
 
+        visualization_payload: Optional[Dict[str, Any]] = None
+        if success:
+            for candidate in self._candidate_field_maps():
+                if not candidate.exists():
+                    continue
+                scenario_path_resolved = scenario_path if scenario_path.exists() else None
+                results_dir = Path(self._app.config["RESULTS_FOLDER"])
+                timestamp = time.strftime("%Y%m%d-%H%M%S")
+                image_path = results_dir / f"field_result_{timestamp}.png"
+                try:
+                    render_field_map_image(
+                        scenario_path_resolved or scenario_path,
+                        candidate,
+                        output_path=image_path,
+                        vector_mode=DEFAULT_VECTOR_MODE,
+                        quiver_skip=DEFAULT_QUIVER_SKIP,
+                        color_scale=DEFAULT_COLOR_SCALE,
+                        draw_boundaries=True,
+                        streamlines=DEFAULT_STREAMLINES,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    self._queue.put({
+                        "message": f"Failed to render final field map: {exc}",
+                        "warning": True,
+                    })
+                    break
+
+                downloads.append(
+                    {
+                        "category": "result",
+                        "filename": image_path.name,
+                        "label": "Field map image",
+                    }
+                )
+                visualization_payload = {
+                    "image": f"/result-image/{image_path.name}",
+                    "caption": "Final field map",
+                }
+                with self._lock:
+                    self._last_result = {
+                        "scenario_path": str(scenario_path),
+                        "field_map": str(candidate),
+                        "image": str(image_path),
+                        "caption": "Final field map",
+                        "settings": {
+                            "vector_mode": DEFAULT_VECTOR_MODE,
+                            "color_scale": DEFAULT_COLOR_SCALE,
+                            "quiver_skip": DEFAULT_QUIVER_SKIP,
+                            "draw_boundaries": True,
+                            "streamlines": DEFAULT_STREAMLINES,
+                        },
+                    }
+                break
+            else:
+                with self._lock:
+                    self._last_result = {"message": "No field map output generated."}
+                visualization_payload = {"message": "No field map output generated."}
+        else:
+            with self._lock:
+                self._last_result = {}
+
         event: Dict[str, Any] = {"complete": True, "message": message, "success": success}
         if success:
             event["progress"] = 100
@@ -211,6 +380,8 @@ class SimulationManager:
             event["stopped"] = True
         if downloads:
             event["downloads"] = downloads
+        if visualization_payload:
+            event["visualization"] = visualization_payload
 
         self._queue.put(event)
         self._stop_requested = False
@@ -251,21 +422,108 @@ def allowed_file(filename: str) -> bool:
     return Path(filename).suffix.lower() in ALLOWED_EXTENSIONS
 
 
+def _build_form_state(overrides: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    state = {
+        "solver": DEFAULT_SOLVER,
+        "tol": f"{DEFAULT_TOLERANCE}",
+        "max_iters": f"{DEFAULT_MAX_ITERS}",
+        "outputs": "",
+    }
+    if overrides:
+        for key, value in overrides.items():
+            if key in state and value is not None:
+                state[key] = value
+    return state
+
+
+def _index_context(
+    *,
+    error: Optional[str] = None,
+    preview_url: Optional[str] = None,
+    preview_error: Optional[str] = None,
+    preview_notice: Optional[str] = None,
+    form_state: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    last_result = manager.get_last_result()
+    last_image_url = None
+    visualization_caption = None
+    visualization_message = last_result.get("message") if last_result else None
+    visualization_defaults = {
+        "vector_mode": DEFAULT_VECTOR_MODE,
+        "color_scale": DEFAULT_COLOR_SCALE,
+        "quiver_skip": DEFAULT_QUIVER_SKIP,
+        "draw_boundaries": True,
+        "streamlines": DEFAULT_STREAMLINES,
+    }
+    if last_result:
+        image_path = Path(last_result.get("image", ""))
+        if image_path.exists():
+            last_image_url = url_for("result_image", filename=image_path.name)
+            visualization_caption = last_result.get("caption")
+            visualization_message = None
+        settings = last_result.get("settings", {})
+        for key in visualization_defaults:
+            if key in settings:
+                visualization_defaults[key] = settings[key]
+
+    return {
+        "running": manager.is_running,
+        "error": error,
+        "form_state": form_state or _build_form_state(),
+        "preview_url": preview_url,
+        "preview_error": preview_error,
+        "preview_notice": preview_notice,
+        "visualization_defaults": visualization_defaults,
+        "last_visualization_url": last_image_url,
+        "last_visualization_caption": visualization_caption,
+        "visualization_message": visualization_message,
+        "DEFAULT_LOG_FLOOR": DEFAULT_LOG_FLOOR,
+    }
+
+
+def _store_scenario_file(geometry) -> Tuple[Path, dict, str]:
+    suffix = Path(geometry.filename).suffix.lower()
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    safe_name = secure_filename(geometry.filename) or f"scenario_{timestamp}{suffix}"
+    scenario_path = Path(app.config["UPLOAD_FOLDER"]) / f"{timestamp}_{safe_name}"
+
+    scenario_path.parent.mkdir(parents=True, exist_ok=True)
+    geometry.save(scenario_path)
+    try:
+        spec = json.loads(scenario_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        scenario_path.unlink(missing_ok=True)
+        raise ValueError("Uploaded JSON is invalid.") from exc
+    return scenario_path, spec, timestamp
+
+
+def _collect_field_outputs(spec: dict, scenario_dir: Path) -> List[Dict[str, Any]]:
+    outputs: List[Dict[str, Any]] = []
+    for entry in spec.get("outputs", []):
+        if entry.get("type") != "field_map":
+            continue
+        identifier = entry.get("id")
+        path_value = entry.get("path")
+        if not path_value and identifier:
+            path_value = f"outputs/{identifier}.csv"
+        if not path_value:
+            continue
+        path = Path(path_value)
+        if not path.is_absolute():
+            path = scenario_dir / path
+        outputs.append({"id": identifier, "path": path})
+    return outputs
+
+
 @app.get("/")
 def index() -> str:
     error = request.args.get("error")
-    return render_template(
-        "index.html",
-        running=manager.is_running,
-        error=error,
-        default_solver=DEFAULT_SOLVER,
-        default_tolerance=DEFAULT_TOLERANCE,
-        default_max_iters=DEFAULT_MAX_ITERS,
-    )
+    return render_template("index.html", **_index_context(error=error))
 
 
 @app.post("/upload")
 def upload() -> Response:
+    action = (request.form.get("action") or "run").lower()
     if manager.is_running:
         return redirect(url_for("index", error="A simulation is already running."))
 
@@ -275,6 +533,42 @@ def upload() -> Response:
 
     if not allowed_file(geometry.filename):
         return redirect(url_for("index", error="Unsupported file type. Use JSON scenarios."))
+
+    suffix = Path(geometry.filename).suffix.lower()
+    if suffix != ".json":
+        return redirect(url_for("index", error="DXF uploads are not supported yet."))
+
+    try:
+        scenario_path, spec, timestamp = _store_scenario_file(geometry)
+    except ValueError as exc:
+        return redirect(url_for("index", error=str(exc)))
+
+    if action == "preview":
+        preview_state = _build_form_state(
+            {
+                "solver": request.form.get("solver"),
+                "tol": request.form.get("tol"),
+                "max_iters": request.form.get("max_iters"),
+                "outputs": request.form.get("outputs"),
+            }
+        )
+        preview_path = Path(app.config["RESULTS_FOLDER"]) / f"geometry_preview_{timestamp}.png"
+        try:
+            render_geometry_preview(scenario_path, preview_path)
+        except RuntimeError as exc:
+            return render_template(
+                "index.html",
+                **_index_context(preview_error=str(exc), form_state=preview_state),
+            )
+
+        return render_template(
+            "index.html",
+            **_index_context(
+                preview_url=url_for("result_image", filename=preview_path.name),
+                preview_notice=f"Preview generated from {geometry.filename}",
+                form_state=preview_state,
+            ),
+        )
 
     solver = (request.form.get("solver") or DEFAULT_SOLVER).lower()
     if solver not in {"cg", "sor"}:
@@ -294,23 +588,6 @@ def upload() -> Response:
 
     outputs_value = (request.form.get("outputs") or "").strip()
 
-    suffix = Path(geometry.filename).suffix.lower()
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    safe_name = secure_filename(geometry.filename) or f"scenario_{timestamp}{suffix}"
-    scenario_path = Path(app.config["UPLOAD_FOLDER"]) / f"{timestamp}_{safe_name}"
-
-    if suffix == ".json":
-        scenario_path.parent.mkdir(parents=True, exist_ok=True)
-        geometry.save(scenario_path)
-        try:
-            json.loads(scenario_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            scenario_path.unlink(missing_ok=True)
-            return redirect(url_for("index", error="Uploaded JSON is invalid."))
-    else:
-        # DXF support is not yet implemented for the Flask prototype.
-        return redirect(url_for("index", error="DXF uploads are not supported yet."))
-
     command = [
         "./build/motor_sim",
         "--scenario",
@@ -329,11 +606,23 @@ def upload() -> Response:
 
     log_path = Path(app.config["RESULTS_FOLDER"]) / f"simulation_{timestamp}.log"
 
+    field_outputs = _collect_field_outputs(spec, scenario_path.parent)
+    extra_downloads = [
+        {
+            "category": "result",
+            "path": str(entry["path"]),
+            "label": f"Field map CSV ({entry['id']})" if entry.get("id") else entry["path"].name,
+        }
+        for entry in field_outputs
+    ]
+
     try:
         manager.start(
             command,
             scenario_path=scenario_path,
             log_path=log_path,
+            extra_downloads=extra_downloads,
+            field_outputs=[{"id": entry.get("id"), "path": str(entry["path"])} for entry in field_outputs],
         )
     except RuntimeError as exc:
         return redirect(url_for("index", error=str(exc)))
@@ -388,6 +677,72 @@ def download() -> Response:
         abort(404)
 
     return send_file(file_path, as_attachment=True)
+
+
+@app.get("/result-image/<path:filename>")
+def result_image(filename: str) -> Response:
+    safe_name = secure_filename(filename)
+    if not safe_name:
+        abort(400)
+
+    file_path = Path(app.config["RESULTS_FOLDER"]) / safe_name
+    if not file_path.exists():
+        abort(404)
+
+    return send_file(file_path, mimetype="image/png")
+
+
+@app.get("/visualization.png")
+def visualization_image() -> Response:
+    last_result = manager.get_last_result()
+    scenario_path = Path(last_result.get("scenario_path", ""))
+    field_map_path = Path(last_result.get("field_map", ""))
+    if not scenario_path.exists() or not field_map_path.exists():
+        abort(404)
+
+    vector_mode = request.args.get("vector", DEFAULT_VECTOR_MODE)
+    if vector_mode not in {"linear", "log", "off"}:
+        abort(400)
+
+    try:
+        quiver_skip = int(request.args.get("skip", DEFAULT_QUIVER_SKIP))
+        if quiver_skip < 1:
+            raise ValueError
+    except ValueError:
+        abort(400)
+
+    color_scale = request.args.get("scale", DEFAULT_COLOR_SCALE)
+    if color_scale not in {"linear", "log"}:
+        abort(400)
+
+    draw_boundaries = request.args.get("boundaries", "1") != "0"
+    streamlines = request.args.get("stream", "0") == "1"
+
+    try:
+        log_floor_value = float(request.args.get("log_floor", DEFAULT_LOG_FLOOR))
+        vector_floor_value = float(request.args.get("vector_floor", DEFAULT_LOG_FLOOR))
+    except ValueError:
+        abort(400)
+
+    data = render_field_map_image(
+        scenario_path,
+        field_map_path,
+        output_path=None,
+        vector_mode=vector_mode,
+        quiver_skip=quiver_skip,
+        color_scale=color_scale,
+        draw_boundaries=draw_boundaries,
+        streamlines=streamlines,
+        log_floor=log_floor_value,
+        vector_log_floor=vector_floor_value,
+    )
+
+    if isinstance(data, Path):  # pragma: no cover - defensive guard
+        payload = data.read_bytes()
+    else:
+        payload = data
+
+    return Response(payload, mimetype="image/png")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution helper

--- a/python/gui/app_flask.py
+++ b/python/gui/app_flask.py
@@ -477,6 +477,7 @@ def _index_context(
         "last_visualization_url": last_image_url,
         "last_visualization_caption": visualization_caption,
         "visualization_message": visualization_message,
+        "visualization_visible": bool(last_result),
         "DEFAULT_LOG_FLOOR": DEFAULT_LOG_FLOOR,
     }
 

--- a/python/gui/render.py
+++ b/python/gui/render.py
@@ -1,0 +1,142 @@
+"""Helpers for rendering geometry previews and field visualisations."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402  - backend configured above
+from matplotlib.patches import Rectangle  # noqa: E402
+
+from python.visualize_scenario_field import (  # noqa: E402
+    Wire,
+    compute_domain_bounds,
+    gather_boundaries,
+    load_field_csv,
+    load_scenario,
+    plot_field,
+    reshape_field,
+)
+
+
+DEFAULT_LOG_FLOOR = 1e-7
+
+
+def render_geometry_preview(scenario_path: Path, output_path: Path) -> Path:
+    """Render a static geometry preview for the supplied scenario."""
+
+    spec, wires = load_scenario(scenario_path)
+    boundaries = {}
+    try:
+        boundaries = gather_boundaries(spec)
+        xmin, xmax, ymin, ymax = compute_domain_bounds(spec)
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    fig, ax = plt.subplots(figsize=(6.0, 5.0))
+
+    width = xmax - xmin
+    height = ymax - ymin
+    rect = Rectangle((xmin, ymin), width, height, fill=False, linewidth=1.6)
+    ax.add_patch(rect)
+
+    for xs, ys, _material in boundaries.get("polygons", []):
+        if len(xs) < 2:
+            continue
+        closed_xs = xs + [xs[0]]
+        closed_ys = ys + [ys[0]]
+        ax.plot(closed_xs, closed_ys, color="tab:blue", linestyle="-", linewidth=1.0, alpha=0.7)
+
+    for xs, ys in boundaries.get("magnet_polygons", []):
+        if len(xs) < 2:
+            continue
+        closed_xs = xs + [xs[0]]
+        closed_ys = ys + [ys[0]]
+        ax.plot(closed_xs, closed_ys, color="tab:red", linestyle=":", linewidth=1.2, alpha=0.9)
+
+    for xmin_m, xmax_m, ymin_m, ymax_m in boundaries.get("magnet_rects", []):
+        rect_x = [xmin_m, xmax_m, xmax_m, xmin_m, xmin_m]
+        rect_y = [ymin_m, ymin_m, ymax_m, ymax_m, ymin_m]
+        ax.plot(rect_x, rect_y, color="tab:red", linestyle=":", linewidth=1.1, alpha=0.9)
+
+    for wire in wires:
+        color = "tab:red" if wire.current >= 0 else "tab:blue"
+        circle = plt.Circle((wire.x, wire.y), wire.radius, color=color, fill=False, linewidth=1.3)
+        ax.add_patch(circle)
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("x [m]")
+    ax.set_ylabel("y [m]")
+    ax.set_title(spec.get("name", scenario_path.name))
+    ax.set_xlim(xmin, xmax)
+    ax.set_ylim(ymin, ymax)
+    ax.grid(False)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def render_field_map_image(
+    scenario_path: Path,
+    field_map_path: Path,
+    *,
+    output_path: Optional[Path] = None,
+    vector_mode: str = "linear",
+    quiver_skip: int = 4,
+    color_scale: str = "linear",
+    draw_boundaries: bool = True,
+    streamlines: bool = False,
+    log_floor: float = DEFAULT_LOG_FLOOR,
+    vector_log_floor: float = DEFAULT_LOG_FLOOR,
+) -> bytes | Path:
+    """Render the field map with the supplied styling options."""
+
+    spec, wires = load_scenario(scenario_path)
+    xs, ys, bxs, bys, bmags = load_field_csv(field_map_path)
+    grid_x, grid_y, (bx, by, bmag) = reshape_field(xs, ys, (bxs, bys, bmags))
+
+    boundaries: Dict[str, List] = {}
+    if draw_boundaries:
+        try:
+            boundaries = gather_boundaries(spec)
+        except ValueError:
+            boundaries = {}
+
+    buffer = io.BytesIO()
+    plot_field(
+        grid_x,
+        grid_y,
+        bx,
+        by,
+        bmag,
+        wires,
+        quiver_skip,
+        buffer,
+        f"Field map: {scenario_path.name}",
+        color_scale,
+        log_floor,
+        draw_boundaries,
+        boundaries,
+        None,
+        vector_mode,
+        vector_log_floor,
+        streamlines,
+        None,
+        0,
+        show=False,
+    )
+
+    data = buffer.getvalue()
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(data)
+        return output_path
+
+    return data

--- a/python/gui/templates/index.html
+++ b/python/gui/templates/index.html
@@ -111,7 +111,7 @@
       </div>
     </div>
     <div class="col-xl-8">
-      <div id="visualization-panel" class="card h-100">
+      <div id="visualization-panel" class="card h-100"{% if not visualization_visible %} style="display: none;"{% endif %}>
         <div class="card-header">Results visualisation</div>
         <div class="card-body">
           <p id="visualization-message" class="text-muted small {% if last_visualization_url %}d-none{% endif %}">
@@ -215,9 +215,16 @@
           progressBar.classList.remove('bg-danger', 'bg-success');
           progressBar.style.width = '0%';
           progressBar.textContent = '0%';
+          if (visualizationPanel) {
+            visualizationPanel.style.display = 'none';
+          }
           if (visualizationMessage) {
-            visualizationMessage.classList.remove('d-none');
-            visualizationMessage.textContent = 'Preparing results…';
+            visualizationMessage.classList.add('d-none');
+            visualizationMessage.textContent = '';
+          }
+          if (visualizationCaption) {
+            visualizationCaption.classList.add('d-none');
+            visualizationCaption.textContent = '';
           }
           if (visualizationError) {
             visualizationError.classList.add('d-none');
@@ -311,6 +318,9 @@
         if (!details) {
           return;
         }
+        if (visualizationPanel) {
+          visualizationPanel.style.display = 'block';
+        }
         if (visualizationError) {
           visualizationError.classList.add('d-none');
           visualizationError.textContent = '';
@@ -337,6 +347,10 @@
           if (visualizationMessage) {
             visualizationMessage.textContent = details.message;
             visualizationMessage.classList.remove('d-none');
+          }
+          resultImage.classList.add('d-none');
+          if (visualizationCaption) {
+            visualizationCaption.classList.add('d-none');
           }
           if (updateVizBtn) {
             updateVizBtn.disabled = true;
@@ -376,6 +390,9 @@
                 URL.revokeObjectURL(currentBlobUrl);
               }
               currentBlobUrl = URL.createObjectURL(blob);
+              if (visualizationPanel) {
+                visualizationPanel.style.display = 'block';
+              }
               resultImage.src = currentBlobUrl;
               resultImage.classList.remove('d-none');
               if (visualizationMessage) {

--- a/python/gui/templates/index.html
+++ b/python/gui/templates/index.html
@@ -1,63 +1,171 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-lg-8">
-      <h1 class="mb-3">Run a Simulation</h1>
-      <p class="text-muted">Upload a scenario JSON, select solver options, and monitor progress in real time.</p>
-      {% if error %}
-        <div class="alert alert-danger" role="alert">
-          {{ error }}
+  <div class="row g-3">
+    <div class="col-xl-4">
+      <div class="card h-100">
+        <div class="card-header">Geometry preview</div>
+        <div class="card-body">
+          {% if preview_notice %}
+            <div class="alert alert-success" role="alert">{{ preview_notice }}</div>
+          {% endif %}
+          {% if preview_error %}
+            <div class="alert alert-danger" role="alert">{{ preview_error }}</div>
+          {% endif %}
+          <p id="preview-placeholder" class="text-muted small {% if preview_url %}d-none{% endif %}">
+            Upload a scenario and choose <strong>Preview geometry</strong> to render the domain outline.
+          </p>
+          <img id="geometry-preview-image" class="img-fluid {% if not preview_url %}d-none{% endif %}" src="{{ preview_url or '' }}" alt="Geometry preview">
         </div>
-      {% endif %}
-      <form id="run-form" class="card card-body mb-3" method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data">
-        <div class="mb-3">
-          <label class="form-label" for="geometry-file">Scenario file (JSON)</label>
-          <input class="form-control" type="file" id="geometry-file" name="geometry_file" accept=".json,.dxf" required>
-          <div class="form-text">DXF uploads are reserved for a future update; please use JSON scenarios for now.</div>
+        <div class="card-footer text-muted small">
+          DXF upload support is planned for a later stage.
         </div>
-        <div class="row g-3">
-          <div class="col-md-4">
-            <label class="form-label" for="solver">Solver</label>
-            <select class="form-select" id="solver" name="solver">
-              <option value="cg" {% if default_solver == 'cg' %}selected{% endif %}>Conjugate Gradient (CG)</option>
-              <option value="sor" {% if default_solver == 'sor' %}selected{% endif %}>Successive Over-Relaxation (SOR)</option>
-            </select>
+      </div>
+    </div>
+    <div class="col-xl-8">
+      <div class="card mb-3">
+        <div class="card-header">Simulation controls</div>
+        <div class="card-body">
+          <p class="text-muted mb-3">Upload a scenario JSON, adjust solver settings, then launch the solve. Geometry previews are generated entirely server-side.</p>
+          {% if error %}
+            <div class="alert alert-danger" role="alert">{{ error }}</div>
+          {% endif %}
+          <form id="run-form" method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data" novalidate>
+            <div class="mb-3">
+              <label class="form-label" for="geometry-file">Scenario file (JSON)</label>
+              <input class="form-control" type="file" id="geometry-file" name="geometry_file" accept=".json,.dxf" required>
+              <div class="form-text">DXF ingestion is on the roadmap; JSON scenarios are supported today.</div>
+            </div>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label class="form-label" for="solver">Solver</label>
+                <select class="form-select" id="solver" name="solver">
+                  <option value="cg" {% if form_state.solver == 'cg' %}selected{% endif %}>Conjugate Gradient (CG)</option>
+                  <option value="sor" {% if form_state.solver == 'sor' %}selected{% endif %}>Successive Over-Relaxation (SOR)</option>
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label class="form-label" for="tol">Tolerance</label>
+                <input class="form-control" type="number" step="any" id="tol" name="tol" value="{{ form_state.tol }}" required>
+              </div>
+              <div class="col-md-4">
+                <label class="form-label" for="max-iters">Max iterations</label>
+                <input class="form-control" type="number" id="max-iters" name="max_iters" value="{{ form_state.max_iters }}" min="1" required>
+              </div>
+            </div>
+            <div class="mb-3 mt-3">
+              <label class="form-label" for="outputs">Outputs (optional)</label>
+              <input class="form-control" type="text" id="outputs" name="outputs" value="{{ form_state.outputs }}" placeholder="field_map">
+              <div class="form-text">Forwarded to <code>motor_sim --outputs</code>; leave blank for the scenario default.</div>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+              <button id="run-btn" class="btn btn-primary" name="action" value="run" type="submit" {% if running %}disabled{% endif %}>Run simulation</button>
+              <button id="preview-btn" class="btn btn-outline-secondary" name="action" value="preview" type="submit" formnovalidate>Preview geometry</button>
+              <button id="stop-btn" class="btn btn-warning" type="button" {% if not running %}disabled{% endif %}>Stop</button>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="card border-secondary text-muted">
+        <div class="card-header">Future enhancements</div>
+        <div class="card-body">
+          <p class="mb-2">Coming soon:</p>
+          <div class="d-flex flex-wrap gap-2">
+            <button class="btn btn-outline-secondary" type="button" disabled>DXF import</button>
+            <button class="btn btn-outline-secondary" type="button" disabled>Animation view</button>
+            <button class="btn btn-outline-secondary" type="button" disabled>Circuit coupling</button>
           </div>
-          <div class="col-md-4">
-            <label class="form-label" for="tol">Tolerance</label>
-            <input class="form-control" type="number" step="any" id="tol" name="tol" value="{{ default_tolerance }}" required>
-          </div>
-          <div class="col-md-4">
-            <label class="form-label" for="max-iters">Max iterations</label>
-            <input class="form-control" type="number" id="max-iters" name="max_iters" value="{{ default_max_iters }}" min="1" required>
-          </div>
         </div>
-        <div class="mb-3 mt-3">
-          <label class="form-label" for="outputs">Outputs (optional)</label>
-          <input class="form-control" type="text" id="outputs" name="outputs" placeholder="field_map">
-          <div class="form-text">Pass through to <code>motor_sim --outputs</code>; leave blank to use the solver default.</div>
-        </div>
-        <div class="d-flex gap-2">
-          <button id="run-btn" class="btn btn-primary" type="submit" {% if running %}disabled{% endif %}>Run simulation</button>
-          <button id="stop-btn" class="btn btn-warning" type="button" {% if not running %}disabled{% endif %}>Stop</button>
-        </div>
-      </form>
+      </div>
     </div>
   </div>
-  <div id="progress-container" class="card card-body mb-3" style="display: none;">
-    <h2 class="h5">Progress</h2>
-    <div class="progress" style="height: 24px;">
-      <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;">0%</div>
+
+  <div class="row g-3 mt-1">
+    <div class="col-lg-6">
+      <div id="progress-container" class="card h-100" style="display: none;">
+        <div class="card-header">Progress</div>
+        <div class="card-body">
+          <div class="progress" style="height: 24px;">
+            <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;">0%</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6">
+      <div id="log-container" class="card h-100" style="display: none;">
+        <div class="card-header">Solver log</div>
+        <div class="card-body">
+          <pre id="log-area" class="bg-dark text-white p-3" style="max-height: 320px; overflow-y: auto;"></pre>
+        </div>
+      </div>
     </div>
   </div>
-  <div id="log-container" class="card card-body mb-3" style="display: none;">
-    <h2 class="h5">Solver log</h2>
-    <pre id="log-area" class="bg-dark text-white p-3" style="max-height: 320px; overflow-y: auto;"></pre>
-  </div>
-  <div id="results" class="card card-body" style="display: none;">
-    <h2 class="h5">Downloads</h2>
-    <ul id="results-list" class="list-group list-group-flush"></ul>
+
+  <div class="row g-3 mt-1">
+    <div class="col-xl-4">
+      <div id="results" class="card h-100" style="display: none;">
+        <div class="card-header">Downloads</div>
+        <div class="card-body">
+          <ul id="results-list" class="list-group list-group-flush"></ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-xl-8">
+      <div id="visualization-panel" class="card h-100">
+        <div class="card-header">Results visualisation</div>
+        <div class="card-body">
+          <p id="visualization-message" class="text-muted small {% if last_visualization_url %}d-none{% endif %}">
+            {{ visualization_message or 'Run a simulation to generate field visualisations.' }}
+          </p>
+          <img id="result-image" class="img-fluid {% if not last_visualization_url %}d-none{% endif %}" src="{{ last_visualization_url or '' }}" alt="Field map visualisation">
+          <p id="visualization-caption" class="mt-2 text-muted small {% if not last_visualization_caption %}d-none{% endif %}">{{ last_visualization_caption }}</p>
+          <form id="visualization-form" class="row g-2 mt-3" data-endpoint="{{ url_for('visualization_image') }}">
+            <div class="col-md-3">
+              <label class="form-label small" for="vector-mode">Vector scaling</label>
+              <select class="form-select form-select-sm" id="vector-mode" name="vector">
+                <option value="linear" {% if visualization_defaults.vector_mode == 'linear' %}selected{% endif %}>Linear</option>
+                <option value="log" {% if visualization_defaults.vector_mode == 'log' %}selected{% endif %}>Logarithmic</option>
+                <option value="off" {% if visualization_defaults.vector_mode == 'off' %}selected{% endif %}>Hidden</option>
+              </select>
+            </div>
+            <div class="col-md-3">
+              <label class="form-label small" for="color-scale">Colour scale</label>
+              <select class="form-select form-select-sm" id="color-scale" name="scale">
+                <option value="linear" {% if visualization_defaults.color_scale == 'linear' %}selected{% endif %}>Linear</option>
+                <option value="log" {% if visualization_defaults.color_scale == 'log' %}selected{% endif %}>Logarithmic</option>
+              </select>
+            </div>
+            <div class="col-md-2">
+              <label class="form-label small" for="quiver-skip">Arrow skip</label>
+              <input class="form-control form-control-sm" type="number" min="1" id="quiver-skip" name="skip" value="{{ visualization_defaults.quiver_skip }}">
+            </div>
+            <div class="col-md-2">
+              <label class="form-label small" for="log-floor">Log floor</label>
+              <input class="form-control form-control-sm" type="number" step="any" id="log-floor" name="log_floor" value="{{ '{:.1e}'.format(DEFAULT_LOG_FLOOR) }}">
+            </div>
+            <div class="col-md-2">
+              <label class="form-label small" for="vector-floor">Vector floor</label>
+              <input class="form-control form-control-sm" type="number" step="any" id="vector-floor" name="vector_floor" value="{{ '{:.1e}'.format(DEFAULT_LOG_FLOOR) }}">
+            </div>
+            <div class="col-md-12">
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="draw-boundaries" name="boundaries" value="1" {% if visualization_defaults.draw_boundaries %}checked{% endif %}>
+                <label class="form-check-label small" for="draw-boundaries">Show region outlines</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="streamlines" name="stream" value="1" {% if visualization_defaults.streamlines %}checked{% endif %}>
+                <label class="form-check-label small" for="streamlines">Streamlines</label>
+              </div>
+            </div>
+            <div class="col-12 d-flex flex-wrap gap-2">
+              <button id="update-visualization" class="btn btn-primary btn-sm" type="button" {% if not last_visualization_url %}disabled{% endif %}>Update visualisation</button>
+              <button class="btn btn-outline-secondary btn-sm" type="button" disabled>Save preset (coming soon)</button>
+            </div>
+          </form>
+          <div id="visualization-error" class="text-danger small mt-2 d-none"></div>
+        </div>
+      </div>
+    </div>
   </div>
 {% endblock %}
 
@@ -73,8 +181,16 @@
       const logArea = document.getElementById("log-area");
       const resultsContainer = document.getElementById("results");
       const resultsList = document.getElementById("results-list");
+      const visualizationPanel = document.getElementById("visualization-panel");
+      const visualizationMessage = document.getElementById("visualization-message");
+      const visualizationCaption = document.getElementById("visualization-caption");
+      const visualizationError = document.getElementById("visualization-error");
+      const resultImage = document.getElementById("result-image");
+      const updateVizBtn = document.getElementById("update-visualization");
+      const vizForm = document.getElementById("visualization-form");
       const downloadBase = "{{ url_for('download') }}";
       const isRunning = {{ 'true' if running else 'false' }};
+      let currentBlobUrl = null;
 
       if (isRunning) {
         progressContainer.style.display = 'block';
@@ -84,7 +200,11 @@
       }
 
       if (runForm) {
-        runForm.addEventListener("submit", function () {
+        runForm.addEventListener("submit", function (event) {
+          const submitter = event.submitter;
+          if (submitter && submitter.value === 'preview') {
+            return;
+          }
           runBtn.disabled = true;
           stopBtn.disabled = false;
           progressContainer.style.display = 'block';
@@ -95,6 +215,17 @@
           progressBar.classList.remove('bg-danger', 'bg-success');
           progressBar.style.width = '0%';
           progressBar.textContent = '0%';
+          if (visualizationMessage) {
+            visualizationMessage.classList.remove('d-none');
+            visualizationMessage.textContent = 'Preparing results…';
+          }
+          if (visualizationError) {
+            visualizationError.classList.add('d-none');
+            visualizationError.textContent = '';
+          }
+          if (updateVizBtn) {
+            updateVizBtn.disabled = true;
+          }
         });
       }
 
@@ -168,8 +299,103 @@
               resultsList.appendChild(entry);
             });
           }
+          if (payload.visualization) {
+            handleVisualization(payload.visualization);
+          }
+        } else if (payload.visualization) {
+          handleVisualization(payload.visualization);
         }
       };
+
+      function handleVisualization(details) {
+        if (!details) {
+          return;
+        }
+        if (visualizationError) {
+          visualizationError.classList.add('d-none');
+          visualizationError.textContent = '';
+        }
+        if (details.image) {
+          const url = details.image + (details.image.includes('?') ? '&' : '?') + 't=' + Date.now();
+          resultImage.src = url;
+          resultImage.classList.remove('d-none');
+          if (visualizationMessage) {
+            visualizationMessage.classList.add('d-none');
+          }
+          if (visualizationCaption) {
+            if (details.caption) {
+              visualizationCaption.textContent = details.caption;
+              visualizationCaption.classList.remove('d-none');
+            } else {
+              visualizationCaption.classList.add('d-none');
+            }
+          }
+          if (updateVizBtn) {
+            updateVizBtn.disabled = false;
+          }
+        } else if (details.message) {
+          if (visualizationMessage) {
+            visualizationMessage.textContent = details.message;
+            visualizationMessage.classList.remove('d-none');
+          }
+          if (updateVizBtn) {
+            updateVizBtn.disabled = true;
+          }
+        }
+      }
+
+      if (updateVizBtn && vizForm) {
+        updateVizBtn.addEventListener('click', function () {
+          if (!vizForm.dataset.endpoint) {
+            return;
+          }
+          const formData = new FormData(vizForm);
+          if (!formData.has('boundaries')) {
+            formData.set('boundaries', document.getElementById('draw-boundaries').checked ? '1' : '0');
+          }
+          if (!formData.has('stream')) {
+            formData.set('stream', document.getElementById('streamlines').checked ? '1' : '0');
+          }
+          const params = new URLSearchParams(formData);
+          params.set('t', Date.now().toString());
+          const endpoint = vizForm.dataset.endpoint + '?' + params.toString();
+          updateVizBtn.disabled = true;
+          if (visualizationError) {
+            visualizationError.classList.add('d-none');
+            visualizationError.textContent = '';
+          }
+          fetch(endpoint)
+            .then(function (response) {
+              if (!response.ok) {
+                throw new Error('Request failed');
+              }
+              return response.blob();
+            })
+            .then(function (blob) {
+              if (currentBlobUrl) {
+                URL.revokeObjectURL(currentBlobUrl);
+              }
+              currentBlobUrl = URL.createObjectURL(blob);
+              resultImage.src = currentBlobUrl;
+              resultImage.classList.remove('d-none');
+              if (visualizationMessage) {
+                visualizationMessage.classList.add('d-none');
+              }
+              if (visualizationCaption) {
+                visualizationCaption.classList.add('d-none');
+              }
+            })
+            .catch(function () {
+              if (visualizationError) {
+                visualizationError.textContent = 'Unable to refresh the visualisation.';
+                visualizationError.classList.remove('d-none');
+              }
+            })
+            .finally(function () {
+              updateVizBtn.disabled = false;
+            });
+        });
+      }
     });
   </script>
 {% endblock %}

--- a/python/visualize_scenario_field.py
+++ b/python/visualize_scenario_field.py
@@ -9,7 +9,7 @@ import json
 import pathlib
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, IO, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
@@ -461,7 +461,7 @@ def plot_field(
     bmag: np.ndarray,
     wires: List[Wire],
     quiver_skip: int,
-    save: pathlib.Path | None,
+    save: pathlib.Path | IO[bytes] | None,
     title: str,
     color_scale: str,
     log_floor: float,
@@ -473,6 +473,8 @@ def plot_field(
     streamlines: bool,
     analytic: Optional[Dict[str, np.ndarray]],
     analytic_levels: int,
+    *,
+    show: bool = True,
 ) -> None:
     fig, ax = plt.subplots(figsize=(7, 6))
     display_mag = bmag
@@ -575,9 +577,13 @@ def plot_field(
 
     if save is not None:
         fig.savefig(save, dpi=200, bbox_inches="tight")
-        print(f"Saved figure to {save}")
+        if isinstance(save, pathlib.Path):
+            print(f"Saved figure to {save}")
 
-    plt.show()
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
 
 
 def main() -> None:

--- a/tests/test_gui_flask.py
+++ b/tests/test_gui_flask.py
@@ -1,12 +1,14 @@
 import io
 import json
 import queue
-import time
 import sys
+import time
 from pathlib import Path
 from typing import List
 
 import pytest
+
+pytest.importorskip("flask")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -88,6 +90,150 @@ def test_upload_starts_simulation(monkeypatch, client):
     assert any(evt.get("started") for evt in events)
     assert any(evt.get("complete") for evt in events)
     assert not app_flask.manager.is_running
+
+
+def test_preview_generates_geometry_image(client):
+    payload = json.dumps(
+        {
+            "version": "0.2",
+            "domain": {"Lx": 0.2, "Ly": 0.1},
+            "sources": [],
+        }
+    ).encode("utf-8")
+
+    response = client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(payload), "preview.json"),
+            "solver": "cg",
+            "tol": "1e-6",
+            "max_iters": "100",
+            "action": "preview",
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    body = response.data.decode("utf-8")
+    assert "geometry-preview-image" in body
+    results_dir = Path(app_flask.app.config["RESULTS_FOLDER"])
+    generated = list(results_dir.glob("geometry_preview_*.png"))
+    assert generated, "Expected a preview image to be created"
+
+
+def test_visualization_route_after_run(monkeypatch, client):
+    stdout_queue: "queue.Queue[str | None]" = queue.Queue()
+
+    class DummyStdout:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            item = stdout_queue.get()
+            if item is None:
+                raise StopIteration
+            return item
+
+    class DummyProcess:
+        def __init__(self) -> None:
+            self.stdout = DummyStdout()
+            self.returncode = 0
+
+        def wait(self) -> int:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.returncode = 143
+
+    def fake_popen(cmd, **kwargs):  # noqa: ANN001 - signature mirrors subprocess
+        return DummyProcess()
+
+    monkeypatch.setattr(app_flask.subprocess, "Popen", fake_popen)
+
+    scenario_payload = json.dumps(
+        {
+            "version": "0.2",
+            "domain": {"Lx": 0.1, "Ly": 0.1},
+            "sources": [
+                {"type": "wire", "x": 0.0, "y": 0.0, "radius": 0.002, "I": 5.0}
+            ],
+            "outputs": [
+                {
+                    "type": "field_map",
+                    "id": "domain_field",
+                    "path": "outputs/test_field.csv",
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+    response = client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(scenario_payload), "scenario.json"),
+            "solver": "cg",
+            "tol": "1e-6",
+            "max_iters": "100",
+            "outputs": "domain_field",
+        },
+        content_type="multipart/form-data",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    deadline = time.time() + 2
+    scenario_path: Path | None = None
+    while time.time() < deadline:
+        scenario = app_flask.manager._metadata.get("scenario_path")  # type: ignore[attr-defined]
+        if isinstance(scenario, Path):
+            scenario_path = scenario
+            break
+        time.sleep(0.01)
+
+    assert scenario_path is not None
+
+    field_path = scenario_path.parent / "outputs" / "test_field.csv"
+    field_path.parent.mkdir(parents=True, exist_ok=True)
+    field_path.write_text(
+        "x,y,Bx,By,Bmag\n"
+        "0.0,0.0,0.1,0.0,0.1\n"
+        "0.05,0.0,0.1,0.0,0.1\n"
+        "0.0,0.05,0.1,0.0,0.1\n"
+        "0.05,0.05,0.1,0.0,0.1\n",
+        encoding="utf-8",
+    )
+
+    stdout_queue.put("10%\n")
+    stdout_queue.put(
+        f"Frame 0: wrote field_map 'domain_field' to {field_path}\n"
+    )
+    stdout_queue.put("Finished\n")
+    stdout_queue.put(None)
+
+    events = []
+    deadline = time.time() + 3
+    while time.time() < deadline:
+        try:
+            item = app_flask.manager.queue.get(timeout=0.1)
+            events.append(item)
+            if item.get("complete"):
+                break
+        except queue.Empty:
+            pass
+
+    assert any("visualization" in evt for evt in events if isinstance(evt, dict))
+    last_result = app_flask.manager.get_last_result()
+    assert Path(last_result.get("field_map", "")).exists()
+
+    viz_response = client.get(
+        "/visualization.png",
+        query_string={"vector": "off", "boundaries": "0", "skip": "2"},
+    )
+    assert viz_response.status_code == 200
+    assert viz_response.mimetype == "image/png"
+    payload = b"".join(viz_response.response)
+    assert payload, "Expected PNG bytes from visualisation route"
 
 
 def test_stop_route_terminates_process(client):


### PR DESCRIPTION
## Summary
- reorganize the Flask template into geometry, progress, results, and future-feature panels with preview and visualization cards
- add server-side helpers for rendering geometry previews and field map images, including SSE updates and customizable visualization endpoints
- extend GUI tests to cover geometry preview, visualization rendering, and document the new workflow in the user guide

## Testing
- pytest tests/test_gui_flask.py

------
https://chatgpt.com/codex/tasks/task_e_68f87495d1c08331a54aefc27808404f