### PR TITLE
Revamp Flask GUI layout with project state

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,4 +5,4 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Flask prototype dependencies plus plotting/dxf helpers reused by the GUI
-RUN pip3 install --no-cache-dir flask flask-cors numpy matplotlib ezdxf
+RUN pip3 install --no-cache-dir flask flask-cors numpy matplotlib ezdxf pytest

--- a/docs/developer-guide/implementation/AGENTS.md
+++ b/docs/developer-guide/implementation/AGENTS.md
@@ -1,0 +1,14 @@
+# Implementation Progress Docs Notes
+
+- This folder hosts running logs that track implementation efforts for major
+  epics (solver, GUI, etc.). Keep entries factual and date-agnostic so the
+  narrative remains evergreen.
+- When you land new capabilities, add concise bullets under the relevant
+  sections rather than rewriting history; older entries provide context for
+  future contributors.
+- If you introduce a new epic, create a sibling progress file and reference it
+  from the MkDocs navigation (`mkdocs.yml`).
+- Tests or code changes that the documentation references should be cited with
+  file paths or module names where possible.
+- Avoid embedding binary artefacts or screenshots here—link to reproducible
+  commands or test cases instead.

--- a/docs/developer-guide/implementation/flask-gui-progress.md
+++ b/docs/developer-guide/implementation/flask-gui-progress.md
@@ -22,6 +22,24 @@ on the GUI-specific milestones.
   endpoint payloads without invoking the real solver binary.
 - Documented usage (`docs/user-guide/gui_flask.md`) and linked the new page into
   the MkDocs navigation.
+- **Stage 1 UI overhaul**:
+  - Split the main page into dedicated geometry, control, progress, downloads,
+    and visualisation panels with placeholders for future DXF/animation work.
+  - Introduced a CAD-style top bar and workflow sidebar so navigation feels
+    closer to desktop tooling while leaving hooks for future menus.
+  - Added geometry preview rendering on demand plus live in-process and final
+    field-map visualisation streamed via SSE.
+  - Introduced configurable plotting controls (vector scaling, density,
+    overlays, logarithmic modes) that regenerate Matplotlib renders on request.
+  - Persisted scenario uploads as per-session projects, enabling preview and run
+    actions without re-uploading; added File-menu routes for exporting or
+    clearing the workspace.
+  - Expanded automated coverage for preview flows, solver output detection,
+    project reuse, and the visualisation endpoint to keep regression protection
+    high.
+  - Added helper scripts (`scripts/setup_gui_env.sh` and
+    `scripts/maintain_gui_env.sh`) so contributors can bootstrap dependencies,
+    prune artefacts, and monitor Python package freshness locally.
 
 ## In-flight / next steps
 
@@ -30,7 +48,9 @@ on the GUI-specific milestones.
 - The progress parser currently looks for percentage tokens in stdout; refining
   this to understand the solver's exact log format will improve the progress bar
   fidelity.
-- Consider persisting additional solver outputs (e.g., field map CSVs) to the
-  downloads list once the CLI contract is finalised.
+- Surface more solver artefacts (line probes, streamlines) alongside field maps
+  once those exporters are exercised in real scenarios.
 - Harden long-running process management for multiple users (per-session queues
   instead of global state) if the GUI graduates beyond a single-user demo.
+- Add screenshot-driven regression tests for the Bootstrap layout when we wire
+  up a lightweight browser harness.

--- a/docs/developer-guide/implementation/flask-gui-progress.md
+++ b/docs/developer-guide/implementation/flask-gui-progress.md
@@ -40,11 +40,15 @@ on the GUI-specific milestones.
   - Added helper scripts (`scripts/setup_gui_env.sh` and
     `scripts/maintain_gui_env.sh`) so contributors can bootstrap dependencies,
     prune artefacts, and monitor Python package freshness locally.
+- Added a DXF workspace with multi-file uploads, layer assignment, combined
+  previews, and scenario-to-DXF export support; introduced `python/gui/dxf_utils.py`
+  to encapsulate parsing and rendering logic and exercised the flow in
+  `tests/test_gui_flask.py`.
 
 ## In-flight / next steps
 
-- DXF ingestion is still stubbed. Once the geometry-to-scenario converter is
-  ready we can replace the placeholder guard in `/upload` with real processing.
+- Broaden DXF support beyond lines/polylines/circles (splines, blocks) and add
+  utilities that map layer selections back into scenario JSON automatically.
 - The progress parser currently looks for percentage tokens in stdout; refining
   this to understand the solver's exact log format will improve the progress bar
   fidelity.

--- a/docs/user-guide/gui_flask.md
+++ b/docs/user-guide/gui_flask.md
@@ -7,10 +7,9 @@ prototype while staying close to the underlying command-line workflow.
 ## Requirements
 
 - A built `motor_sim` executable in `./build/motor_sim`.
-- The devcontainer (or local virtual environment) must include Flask and its
-  lightweight companions. The repository's `.devcontainer/Dockerfile` installs
-  Flask, Flask-CORS, NumPy, Matplotlib, and `ezdxf` so the GUI has everything it
-  needs when launched inside Codespaces.
+- Flask, Matplotlib, and NumPy available in the active Python environment.
+  Execute `./scripts/setup_gui_env.sh` to install the trio (and create the GUI
+  runtime folders) when a pre-provisioned devcontainer is not available.
 
 ## Starting the server
 
@@ -29,30 +28,71 @@ prefer Flask's CLI wrapper.
 
 ## Using the interface
 
-1. Upload a scenario JSON file via the **Scenario file** input. (DXF uploads are
-   reserved for a future update and currently return a validation error.)
-2. Pick a solver (`cg` or `sor`), adjust the tolerance and maximum iteration
-   count if required, and optionally pass a value for `--outputs`.
-3. Click **Run simulation**. The form disables itself, the **Stop** button
-   becomes available, and a progress card appears.
-4. The server streams the solver's stdout via Server-Sent Events (SSE). The
-   progress bar reacts to any percentage tokens in the log, and the log panel
-   fills with the live output.
-5. When the run finishes, the log persists and a **Downloads** card appears with
-   links to the uploaded scenario and the captured log file. The log is useful
-   for sharing solver traces without leaving the browser.
-6. Click **Run simulation** again to process another scenario. Only one solve is
-   allowed at a time; the interface reports an error if you attempt to start a
-   second run before the first completes.
+The CAD-inspired layout splits the page into a top navigation bar, a workflow
+sidebar, and content panels for each stage. The **File** menu exposes
+project-wide actions (**New project** clears the workspace, **Save scenario…**
+downloads the current JSON), while the sidebar links jump to the key panels
+without leaving the page.
 
-Use the **Stop** button to request early termination. The server sends
-`terminate()` to the subprocess and the final log entry marks the stop request.
-Depending on solver state, expect a short delay while the child process exits.
+1. Visit the **Simulation setup** panel to upload a scenario JSON file. If
+   you're continuing work on an existing project, the hidden form state preserves
+   the previously uploaded file—you only need to upload again when swapping to a
+   different scenario. DXF uploads remain disabled until the converter ships.
+2. Adjust solver parameters in the same panel. Solver (`cg` or `sor`),
+   tolerance, maximum iterations, and an optional `--outputs` override all map
+   directly to the CLI arguments used when launching `motor_sim`.
+3. Use **Preview geometry** to render the domain outline without running the
+   solver. The preview is cached with the project so you can revisit other
+   panels without losing the image. Any new upload replaces the stored preview.
+4. Click **Run simulation**. The run button disables itself, the **Stop** button
+   becomes active, and the **Progress**/**Solver log** cards appear. The log is
+   streamed via server‑sent events to avoid polling.
+5. Watch the run unfold: percentage tokens update the progress bar, log entries
+   append live, and any `field_map` outputs mentioned in stdout trigger a fresh
+   render in the **Results visualisation** panel. Intermediate images replace
+   the geometry preview automatically.
+6. When the solver exits, the **Downloads** panel lists the uploaded scenario,
+   the log file, and any field-map artefacts made available by the solver. The
+   visualisation panel shows the final render and stays wired to the plotting
+   controls so you can iterate on overlays without rerunning the simulation.
+
+Only one solve is allowed at a time; the interface reports an error if you try
+to launch a second run before the first finishes. Use **Stop** to request
+termination—`terminate()` is sent to the subprocess and the log records the
+request before the child exits.
+
+### Environment upkeep
+
+Generated artefacts accumulate under `python/gui/uploads` and
+`python/gui/results`. Run `./scripts/maintain_gui_env.sh` periodically (set
+`KEEP_DAYS` or pass a day count to keep more history) to prune stale files and
+surface any outdated Python packages.
+
+### Visualisation controls
+
+The results card includes a lightweight form for regenerating the field-map
+image without leaving the browser:
+
+- **Vector scaling**: switch between linear arrows, logarithmic scaling, or hide
+  vectors entirely.
+- **Colour scale**: toggle between linear and logarithmic magnitude mapping.
+- **Arrow skip**: control the quiver density (defaults to every fourth sample).
+- **Log floor / Vector floor**: clamp low values when using logarithmic modes.
+- **Region outlines / Streamlines**: enable or disable material/magnet borders
+  and streamline overlays.
+
+Choose the desired parameters and click **Update visualisation**. The server
+re-renders the image with Matplotlib and returns a fresh PNG via the
+`/visualization.png` endpoint, keeping the UI responsive with minimal
+JavaScript.
 
 ## Known limitations
 
 - DXF geometry ingestion is stubbed; use JSON scenarios generated via the
   existing Python helpers until the converter is available.
+- Preview and visualisation rendering rely on Matplotlib and NumPy. These
+  dependencies ship with the devcontainer, but a custom environment must supply
+  the same stack.
 - The progress parser uses a simple percentage heuristic. If the solver log does
   not emit percentage tokens the bar will stay at 0 % until the run completes.
 - The current prototype keeps global state and targets single-user usage. A

--- a/docs/user-guide/gui_flask.md
+++ b/docs/user-guide/gui_flask.md
@@ -7,9 +7,10 @@ prototype while staying close to the underlying command-line workflow.
 ## Requirements
 
 - A built `motor_sim` executable in `./build/motor_sim`.
-- Flask, Matplotlib, and NumPy available in the active Python environment.
-  Execute `./scripts/setup_gui_env.sh` to install the trio (and create the GUI
-  runtime folders) when a pre-provisioned devcontainer is not available.
+- Flask, Matplotlib, NumPy, and ezdxf available in the active Python
+  environment. Execute `./scripts/setup_gui_env.sh` to install the toolchain
+  (and create the GUI runtime folders) when a pre-provisioned devcontainer is
+  not available.
 
 ## Starting the server
 
@@ -31,30 +32,36 @@ prefer Flask's CLI wrapper.
 The CAD-inspired layout splits the page into a top navigation bar, a workflow
 sidebar, and content panels for each stage. The **File** menu exposes
 project-wide actions (**New project** clears the workspace, **Save scenario…**
-downloads the current JSON), while the sidebar links jump to the key panels
-without leaving the page.
+downloads the current JSON, **Export DXF set…** produces layered DXFs for the
+current scenario), while the sidebar links jump to the key panels without
+leaving the page.
 
-1. Visit the **Simulation setup** panel to upload a scenario JSON file. If
-   you're continuing work on an existing project, the hidden form state preserves
-   the previously uploaded file—you only need to upload again when swapping to a
-   different scenario. DXF uploads remain disabled until the converter ships.
-2. Adjust solver parameters in the same panel. Solver (`cg` or `sor`),
-   tolerance, maximum iterations, and an optional `--outputs` override all map
-   directly to the CLI arguments used when launching `motor_sim`.
-3. Use **Preview geometry** to render the domain outline without running the
-   solver. The preview is cached with the project so you can revisit other
-   panels without losing the image. Any new upload replaces the stored preview.
-4. Click **Run simulation**. The run button disables itself, the **Stop** button
-   becomes active, and the **Progress**/**Solver log** cards appear. The log is
-   streamed via server‑sent events to avoid polling.
-5. Watch the run unfold: percentage tokens update the progress bar, log entries
-   append live, and any `field_map` outputs mentioned in stdout trigger a fresh
-   render in the **Results visualisation** panel. Intermediate images replace
-   the geometry preview automatically.
-6. When the solver exits, the **Downloads** panel lists the uploaded scenario,
-   the log file, and any field-map artefacts made available by the solver. The
-   visualisation panel shows the final render and stays wired to the plotting
-   controls so you can iterate on overlays without rerunning the simulation.
+1. Visit the **CAD workspace** to import DXF files when you want to assemble or
+   revise geometry. Each upload is summarised by layer; select the layers to
+   include, assign a category (material, magnet, wire, etc.), and click **Update
+   mapping** to refresh the combined preview. The preview colours match the
+   chosen categories so you can confirm alignments before committing to a
+   scenario JSON.
+2. Use the **Simulation setup** panel to upload (or re-upload) a scenario JSON
+   when you are ready to run the solver. The form preserves solver defaults so
+   you only need to change the file when switching projects. Optional solver
+   arguments—`cg`/`sor`, tolerance, iteration limit, and `--outputs`—map directly
+   onto the `motor_sim` CLI.
+3. Choose **Preview geometry** to render the domain outline without solving.
+   Previews stay cached with the project and coexist with the DXF preview so you
+   can compare imported geometry with the scenario domain.
+4. Click **Run simulation** to launch `motor_sim`. The run button disables
+   itself, the **Stop** button becomes active, and the **Progress**/**Solver log**
+   cards appear. Logs stream via server-sent events, avoiding polling.
+5. Monitor the run: percentage tokens update the progress bar, log entries append
+   live, and any `field_map` outputs mentioned in stdout trigger refreshed images
+   in the **Results visualisation** panel. Intermediate renders replace the
+   preview automatically.
+6. Once the solver exits, the **Downloads** panel lists the uploaded scenario,
+   the log file, the combined DXF exports (when requested), and any field-map
+   artefacts produced by the solver. The visualisation panel shows the final
+   render and stays wired to the plotting controls so you can iterate on overlays
+   without rerunning the simulation.
 
 Only one solve is allowed at a time; the interface reports an error if you try
 to launch a second run before the first finishes. Use **Stop** to request
@@ -88,11 +95,12 @@ JavaScript.
 
 ## Known limitations
 
-- DXF geometry ingestion is stubbed; use JSON scenarios generated via the
-  existing Python helpers until the converter is available.
-- Preview and visualisation rendering rely on Matplotlib and NumPy. These
-  dependencies ship with the devcontainer, but a custom environment must supply
-  the same stack.
+- DXF ingestion currently supports LINE/POLYLINE/LWPOLYLINE and CIRCLE entities.
+  Splines, text, and block references are ignored. Use your CAD tool to explode
+  complex geometry before uploading.
+- Preview and visualisation rendering rely on Matplotlib, NumPy, and ezdxf.
+  These dependencies ship with the devcontainer, but a custom environment must
+  provide the same stack.
 - The progress parser uses a simple percentage heuristic. If the solver log does
   not emit percentage tokens the bar will stay at 0 % until the run completes.
 - The current prototype keeps global state and targets single-user usage. A

--- a/python/gui/AGENTS.md
+++ b/python/gui/AGENTS.md
@@ -7,8 +7,18 @@
 - Reuse the existing `SimulationManager` helper when wiring new routes. Ensure
   updates remain thread-safe and continue to enforce the single-simulation
   constraint.
+- Stage 1 of the GUI overhaul introduced geometry previews, live field-map
+  visualisation, and the `/visualization.png` customisation endpoint. The UI now
+  includes a CAD-style top bar, workflow sidebar, and a project-aware workspace
+  summary. Keep the File-menu actions (`/project/reset`, `/project/scenario`)
+  and per-session project state intact when iterating on features.
+- Follow-up work should expand tests when touching related code—fixtures clear
+  `PROJECTS`, so new project-oriented behaviour needs explicit coverage.
 - When modifying behaviour, update the user guide (`docs/user-guide/gui_flask.md`)
   and extend `tests/test_gui_flask.py` so new code paths stay covered.
 - Runtime artefacts such as uploads and generated logs should stay out of the
   repository. Use or extend the ignore rules in this directory if new folders
   are introduced.
+- The helper scripts `scripts/setup_gui_env.sh` and
+  `scripts/maintain_gui_env.sh` keep local environments reproducible—run them
+  before hacking on the GUI or when tidying accumulated artefacts.

--- a/python/gui/AGENTS.md
+++ b/python/gui/AGENTS.md
@@ -8,10 +8,15 @@
   updates remain thread-safe and continue to enforce the single-simulation
   constraint.
 - Stage 1 of the GUI overhaul introduced geometry previews, live field-map
-  visualisation, and the `/visualization.png` customisation endpoint. The UI now
-  includes a CAD-style top bar, workflow sidebar, and a project-aware workspace
-  summary. Keep the File-menu actions (`/project/reset`, `/project/scenario`)
-  and per-session project state intact when iterating on features.
+  visualisation, the DXF workspace, and the `/visualization.png` customisation
+  endpoint. The UI now includes a CAD-style top bar, workflow sidebar, and a
+  project-aware workspace summary. Keep the File-menu actions
+  (`/project/reset`, `/project/scenario`, `/project/export_dxf`) and
+  per-session project state intact when iterating on features.
+- DXF handling lives in `python/gui/dxf_utils.py`; reuse its helpers when
+  parsing uploads, rendering previews, or exporting geometry. Layer selections
+  are stored in `PROJECTS[pid]['dxf_files']`—mutations should be mirrored in
+  tests to preserve coverage.
 - Follow-up work should expand tests when touching related code—fixtures clear
   `PROJECTS`, so new project-oriented behaviour needs explicit coverage.
 - When modifying behaviour, update the user guide (`docs/user-guide/gui_flask.md`)

--- a/python/gui/app_flask.py
+++ b/python/gui/app_flask.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import queue
+import re
 import subprocess
 import threading
 import time
+import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from flask import (
     Flask,
@@ -17,10 +19,17 @@ from flask import (
     redirect,
     render_template,
     request,
-    url_for,
     send_file,
+    session,
+    url_for,
 )
 from werkzeug.utils import secure_filename
+
+from python.gui.render import (
+    DEFAULT_LOG_FLOOR,
+    render_field_map_image,
+    render_geometry_preview,
+)
 
 
 ALLOWED_EXTENSIONS = {".json", ".dxf"}
@@ -28,6 +37,13 @@ DEFAULT_SOLVER = "cg"
 DEFAULT_TOLERANCE = 1e-6
 DEFAULT_MAX_ITERS = 20000
 MAX_UPLOAD_SIZE_MB = 50
+DEFAULT_VECTOR_MODE = "linear"
+DEFAULT_COLOR_SCALE = "linear"
+DEFAULT_QUIVER_SKIP = 4
+DEFAULT_STREAMLINES = False
+FIELD_MAP_REGEX = re.compile(
+    r"Frame\\s+(?P<frame>\\d+):\\s+wrote\\s+field_map\\s+'(?P<id>[^']+)'\\s+to\\s+(?P<path>.+)"
+)
 
 
 class SimulationManager:
@@ -42,6 +58,7 @@ class SimulationManager:
         self._running = False
         self._stop_requested = False
         self._metadata: Dict[str, Any] = {}
+        self._last_result: Dict[str, Any] = {}
 
     @property
     def is_running(self) -> bool:
@@ -51,6 +68,10 @@ class SimulationManager:
     def queue(self) -> "queue.Queue[Dict[str, Any]]":
         return self._queue
 
+    def get_last_result(self) -> Dict[str, Any]:
+        with self._lock:
+            return dict(self._last_result)
+
     def start(
         self,
         command: List[str],
@@ -58,6 +79,7 @@ class SimulationManager:
         scenario_path: Path,
         log_path: Path,
         extra_downloads: Optional[List[Dict[str, Any]]] = None,
+        field_outputs: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
         with self._lock:
             if self._running:
@@ -69,6 +91,8 @@ class SimulationManager:
                 "scenario_path": scenario_path,
                 "log_path": log_path,
                 "extra_downloads": extra_downloads or [],
+                "field_outputs": field_outputs or [],
+                "processed_field_maps": set(),
             }
             self._queue.put({
                 "started": True,
@@ -104,6 +128,13 @@ class SimulationManager:
             self._running = False
             self._stop_requested = False
             self._metadata = {}
+            self._last_result = {}
+
+    def clear_last_result(self) -> None:
+        """Discard the cached visualisation payload."""
+
+        with self._lock:
+            self._last_result = {}
 
     def _drain_queue_locked(self) -> None:
         while True:
@@ -111,6 +142,83 @@ class SimulationManager:
                 self._queue.get_nowait()
             except queue.Empty:
                 break
+
+    def _handle_field_map_event(self, *, frame: Optional[int], field_id: str, path_str: str) -> None:
+        scenario_path: Optional[Path] = self._metadata.get("scenario_path")
+        if scenario_path is None or not scenario_path.exists():
+            return
+
+        cleaned_path = path_str.strip().strip('"').strip("'")
+        if not cleaned_path:
+            return
+
+        output_path = Path(cleaned_path)
+        if not output_path.is_absolute():
+            output_path = scenario_path.parent / output_path
+
+        if not output_path.exists():
+            return
+
+        with self._lock:
+            processed: Set[Path] = self._metadata.setdefault("processed_field_maps", set())
+            if output_path in processed:
+                return
+            processed.add(output_path)
+
+        results_dir = Path(self._app.config["RESULTS_FOLDER"])
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        frame_suffix = f"_frame{frame}" if frame is not None else ""
+        filename = f"field_progress_{timestamp}{frame_suffix}.png"
+        image_path = results_dir / filename
+
+        try:
+            render_field_map_image(
+                scenario_path,
+                output_path,
+                output_path=image_path,
+                vector_mode=DEFAULT_VECTOR_MODE,
+                quiver_skip=DEFAULT_QUIVER_SKIP,
+                color_scale=DEFAULT_COLOR_SCALE,
+                draw_boundaries=True,
+                streamlines=DEFAULT_STREAMLINES,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self._queue.put({
+                "message": f"Failed to render field map '{field_id}': {exc}",
+                "warning": True,
+            })
+            return
+
+        with self._lock:
+            self._metadata["latest_field_map"] = output_path
+            self._metadata["latest_image"] = image_path
+
+        caption = f"Frame {frame} field map" if frame is not None else f"Field map '{field_id}'"
+        self._queue.put(
+            {
+                "visualization": {
+                    "image": f"/result-image/{image_path.name}",
+                    "caption": caption,
+                }
+            }
+        )
+
+    def _candidate_field_maps(self) -> List[Path]:
+        scenario_path: Optional[Path] = self._metadata.get("scenario_path")
+        scenario_dir = scenario_path.parent if scenario_path else None
+        candidates: List[Path] = []
+        latest = self._metadata.get("latest_field_map")
+        if isinstance(latest, Path):
+            candidates.append(latest)
+        for entry in self._metadata.get("field_outputs", []):
+            path_value = entry.get("path")
+            if not path_value:
+                continue
+            path = Path(path_value)
+            if not path.is_absolute() and scenario_dir is not None:
+                path = scenario_dir / path
+            candidates.append(path)
+        return candidates
 
     def _run_process(self, command: List[str]) -> None:
         log_path: Path = self._metadata["log_path"]
@@ -154,6 +262,18 @@ class SimulationManager:
                     if progress is not None:
                         event["progress"] = progress
                     self._queue.put(event)
+
+                    match = FIELD_MAP_REGEX.match(line)
+                    if match:
+                        frame_value = match.group("frame")
+                        frame = int(frame_value) if frame_value is not None else None
+                        field_id = match.group("id")
+                        path_str = match.group("path")
+                        self._handle_field_map_event(
+                            frame=frame,
+                            field_id=field_id,
+                            path_str=path_str,
+                        )
 
                 return_code = process.wait()
                 success = return_code == 0 and not self._stop_requested
@@ -204,6 +324,67 @@ class SimulationManager:
                 }
             )
 
+        visualization_payload: Optional[Dict[str, Any]] = None
+        if success:
+            for candidate in self._candidate_field_maps():
+                if not candidate.exists():
+                    continue
+                scenario_path_resolved = scenario_path if scenario_path.exists() else None
+                results_dir = Path(self._app.config["RESULTS_FOLDER"])
+                timestamp = time.strftime("%Y%m%d-%H%M%S")
+                image_path = results_dir / f"field_result_{timestamp}.png"
+                try:
+                    render_field_map_image(
+                        scenario_path_resolved or scenario_path,
+                        candidate,
+                        output_path=image_path,
+                        vector_mode=DEFAULT_VECTOR_MODE,
+                        quiver_skip=DEFAULT_QUIVER_SKIP,
+                        color_scale=DEFAULT_COLOR_SCALE,
+                        draw_boundaries=True,
+                        streamlines=DEFAULT_STREAMLINES,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    self._queue.put({
+                        "message": f"Failed to render final field map: {exc}",
+                        "warning": True,
+                    })
+                    break
+
+                downloads.append(
+                    {
+                        "category": "result",
+                        "filename": image_path.name,
+                        "label": "Field map image",
+                    }
+                )
+                visualization_payload = {
+                    "image": f"/result-image/{image_path.name}",
+                    "caption": "Final field map",
+                }
+                with self._lock:
+                    self._last_result = {
+                        "scenario_path": str(scenario_path),
+                        "field_map": str(candidate),
+                        "image": str(image_path),
+                        "caption": "Final field map",
+                        "settings": {
+                            "vector_mode": DEFAULT_VECTOR_MODE,
+                            "color_scale": DEFAULT_COLOR_SCALE,
+                            "quiver_skip": DEFAULT_QUIVER_SKIP,
+                            "draw_boundaries": True,
+                            "streamlines": DEFAULT_STREAMLINES,
+                        },
+                    }
+                break
+            else:
+                with self._lock:
+                    self._last_result = {"message": "No field map output generated."}
+                visualization_payload = {"message": "No field map output generated."}
+        else:
+            with self._lock:
+                self._last_result = {}
+
         event: Dict[str, Any] = {"complete": True, "message": message, "success": success}
         if success:
             event["progress"] = 100
@@ -211,6 +392,8 @@ class SimulationManager:
             event["stopped"] = True
         if downloads:
             event["downloads"] = downloads
+        if visualization_payload:
+            event["visualization"] = visualization_payload
 
         self._queue.put(event)
         self._stop_requested = False
@@ -244,72 +427,326 @@ app.config.update(
 Path(app.config["UPLOAD_FOLDER"]).mkdir(parents=True, exist_ok=True)
 Path(app.config["RESULTS_FOLDER"]).mkdir(parents=True, exist_ok=True)
 
+app.secret_key = "mag-sim-gui"
+
 manager = SimulationManager(app)
+
+PROJECTS: Dict[str, Dict[str, Any]] = {}
 
 
 def allowed_file(filename: str) -> bool:
     return Path(filename).suffix.lower() in ALLOWED_EXTENSIONS
 
 
+def _build_form_state(overrides: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    state = {
+        "solver": DEFAULT_SOLVER,
+        "tol": f"{DEFAULT_TOLERANCE}",
+        "max_iters": f"{DEFAULT_MAX_ITERS}",
+        "outputs": "",
+    }
+    if overrides:
+        for key, value in overrides.items():
+            if key in state and value is not None:
+                state[key] = value
+    return state
+
+
+def _register_project(
+    scenario_path: Path, spec: Dict[str, Any], original_name: str
+) -> Tuple[str, Dict[str, Any]]:
+    project_id = uuid.uuid4().hex
+    PROJECTS[project_id] = {
+        "scenario_path": scenario_path,
+        "spec": spec,
+        "original_filename": original_name,
+        "scenario_name": spec.get("name"),
+        "created_label": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "preview_path": None,
+        "preview_notice": None,
+        "preview_version": None,
+        "form_state": _build_form_state(),
+    }
+    return project_id, PROJECTS[project_id]
+
+
+def _discard_project(project_id: str) -> None:
+    project = PROJECTS.pop(project_id, None)
+    if not project:
+        return
+
+    preview_path = project.get("preview_path")
+    if isinstance(preview_path, Path):
+        preview_path.unlink(missing_ok=True)
+
+    scenario_path = project.get("scenario_path")
+    if isinstance(scenario_path, Path):
+        scenario_path.unlink(missing_ok=True)
+
+
+def _current_project(
+    explicit_id: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    project_id = explicit_id or session.get("project_id")
+    if not project_id:
+        return None, None
+
+    project = PROJECTS.get(project_id)
+    if project is None:
+        if explicit_id is None:
+            session.pop("project_id", None)
+        return None, None
+
+    return project_id, project
+
+
+def _index_context(
+    *,
+    error: Optional[str] = None,
+    preview_url: Optional[str] = None,
+    preview_error: Optional[str] = None,
+    preview_notice: Optional[str] = None,
+    form_state: Optional[Dict[str, str]] = None,
+    project_id: Optional[str] = None,
+    status_message: Optional[str] = None,
+) -> Dict[str, Any]:
+    active_id, project = _current_project(project_id)
+
+    if form_state is None:
+        if project and project.get("form_state"):
+            form_state = dict(project["form_state"])
+        else:
+            form_state = _build_form_state()
+    else:
+        form_state = _build_form_state(form_state)
+
+    preview_source = preview_url
+    preview_token = None
+    notice = preview_notice
+    if project:
+        stored_preview = project.get("preview_path")
+        if stored_preview and Path(stored_preview).exists():
+            if not preview_source:
+                preview_source = url_for("result_image", filename=Path(stored_preview).name)
+            preview_token = project.get("preview_version")
+        if not notice and project.get("preview_notice"):
+            notice = project["preview_notice"]
+
+    last_result = manager.get_last_result()
+    last_image_url = None
+    visualization_caption = None
+    visualization_message = last_result.get("message") if last_result else None
+    visualization_defaults = {
+        "vector_mode": DEFAULT_VECTOR_MODE,
+        "color_scale": DEFAULT_COLOR_SCALE,
+        "quiver_skip": DEFAULT_QUIVER_SKIP,
+        "draw_boundaries": True,
+        "streamlines": DEFAULT_STREAMLINES,
+    }
+    if last_result:
+        image_path = Path(last_result.get("image", ""))
+        if image_path.exists():
+            last_image_url = url_for("result_image", filename=image_path.name)
+            visualization_caption = last_result.get("caption")
+            visualization_message = None
+        settings = last_result.get("settings", {})
+        for key in visualization_defaults:
+            if key in settings:
+                visualization_defaults[key] = settings[key]
+
+    project_summary = None
+    if project and active_id:
+        project_summary = {
+            "id": active_id,
+            "filename": project.get("original_filename"),
+            "scenario_name": project.get("scenario_name"),
+            "created_label": project.get("created_label"),
+        }
+
+    return {
+        "running": manager.is_running,
+        "error": error,
+        "form_state": form_state,
+        "preview_url": preview_source,
+        "preview_error": preview_error,
+        "preview_notice": notice,
+        "preview_token": preview_token,
+        "visualization_defaults": visualization_defaults,
+        "last_visualization_url": last_image_url,
+        "last_visualization_caption": visualization_caption,
+        "visualization_message": visualization_message,
+        "visualization_visible": bool(last_result),
+        "DEFAULT_LOG_FLOOR": DEFAULT_LOG_FLOOR,
+        "project": project_summary,
+        "has_project": project_summary is not None,
+        "project_download_url": url_for("project_scenario") if project_summary else None,
+        "form_requires_file": project_summary is None,
+        "status_message": status_message,
+    }
+
+
+def _store_scenario_file(geometry) -> Tuple[Path, dict, str, str]:
+    suffix = Path(geometry.filename).suffix.lower()
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    original_name = geometry.filename or f"scenario_{timestamp}{suffix}"
+    safe_name = secure_filename(original_name) or f"scenario_{timestamp}{suffix}"
+    scenario_path = Path(app.config["UPLOAD_FOLDER"]) / f"{timestamp}_{safe_name}"
+
+    scenario_path.parent.mkdir(parents=True, exist_ok=True)
+    geometry.save(scenario_path)
+    try:
+        spec = json.loads(scenario_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        scenario_path.unlink(missing_ok=True)
+        raise ValueError("Uploaded JSON is invalid.") from exc
+    return scenario_path, spec, timestamp, original_name
+
+
+def _collect_field_outputs(spec: dict, scenario_dir: Path) -> List[Dict[str, Any]]:
+    outputs: List[Dict[str, Any]] = []
+    for entry in spec.get("outputs", []):
+        if entry.get("type") != "field_map":
+            continue
+        identifier = entry.get("id")
+        path_value = entry.get("path")
+        if not path_value and identifier:
+            path_value = f"outputs/{identifier}.csv"
+        if not path_value:
+            continue
+        path = Path(path_value)
+        if not path.is_absolute():
+            path = scenario_dir / path
+        outputs.append({"id": identifier, "path": path})
+    return outputs
+
+
 @app.get("/")
 def index() -> str:
     error = request.args.get("error")
+    notice = request.args.get("notice")
     return render_template(
         "index.html",
-        running=manager.is_running,
-        error=error,
-        default_solver=DEFAULT_SOLVER,
-        default_tolerance=DEFAULT_TOLERANCE,
-        default_max_iters=DEFAULT_MAX_ITERS,
+        **_index_context(error=error, status_message=notice),
     )
 
 
 @app.post("/upload")
 def upload() -> Response:
+    action = (request.form.get("action") or "run").lower()
     if manager.is_running:
         return redirect(url_for("index", error="A simulation is already running."))
 
     geometry = request.files.get("geometry_file")
-    if geometry is None or geometry.filename == "":
-        return redirect(url_for("index", error="Select a scenario JSON before running."))
+    project_hint = request.form.get("project_id")
+    current_project_id = session.get("project_id")
 
-    if not allowed_file(geometry.filename):
-        return redirect(url_for("index", error="Unsupported file type. Use JSON scenarios."))
+    project_id: Optional[str] = None
+    project: Optional[Dict[str, Any]] = None
+    scenario_path: Optional[Path] = None
+    spec: Optional[Dict[str, Any]] = None
 
-    solver = (request.form.get("solver") or DEFAULT_SOLVER).lower()
+    if geometry is not None and geometry.filename:
+        if not allowed_file(geometry.filename):
+            return redirect(url_for("index", error="Unsupported file type. Use JSON scenarios."))
+
+        suffix = Path(geometry.filename).suffix.lower()
+        if suffix != ".json":
+            return redirect(url_for("index", error="DXF uploads are not supported yet."))
+
+        if current_project_id and current_project_id in PROJECTS:
+            _discard_project(current_project_id)
+
+        try:
+            scenario_path, spec, _, original_name = _store_scenario_file(geometry)
+        except ValueError as exc:
+            return redirect(url_for("index", error=str(exc)))
+
+        project_id, project = _register_project(scenario_path, spec, original_name)
+        session["project_id"] = project_id
+    else:
+        project_id, project = _current_project(project_hint)
+        if project is None:
+            return redirect(url_for("index", error="Select or upload a scenario before continuing."))
+
+        scenario_path = project.get("scenario_path")
+        spec = project.get("spec")
+        if not isinstance(scenario_path, Path) or not scenario_path.exists():
+            return redirect(url_for("index", error="Scenario file is missing for this project."))
+        if not isinstance(spec, dict):
+            return redirect(url_for("index", error="Scenario metadata is unavailable for this project."))
+
+    assert project_id is not None and project is not None
+    session["project_id"] = project_id
+    if scenario_path is None:
+        scenario_path = project["scenario_path"]
+    if spec is None:
+        spec = project["spec"]
+
+    form_state = _build_form_state(
+        {
+            "solver": request.form.get("solver"),
+            "tol": request.form.get("tol"),
+            "max_iters": request.form.get("max_iters"),
+            "outputs": request.form.get("outputs"),
+        }
+    )
+    project["form_state"] = dict(form_state)
+    project["spec"] = spec
+    project["scenario_path"] = scenario_path
+    project["scenario_name"] = spec.get("name")
+
+    if action == "preview":
+        preview_path_existing = project.get("preview_path")
+        if isinstance(preview_path_existing, Path):
+            preview_path_existing.unlink(missing_ok=True)
+
+        preview_filename = f"geometry_preview_{project_id}_{time.strftime('%Y%m%d-%H%M%S')}.png"
+        preview_path = Path(app.config["RESULTS_FOLDER"]) / preview_filename
+        try:
+            render_geometry_preview(scenario_path, preview_path)
+        except RuntimeError as exc:
+            project["preview_path"] = None
+            project["preview_version"] = None
+            project["preview_notice"] = None
+            return render_template(
+                "index.html",
+                **_index_context(
+                    preview_error=str(exc),
+                    form_state=form_state,
+                    project_id=project_id,
+                ),
+            )
+
+        project["preview_path"] = preview_path
+        project["preview_notice"] = (
+            f"Preview generated from {project.get('original_filename') or scenario_path.name}"
+        )
+        project["preview_version"] = time.time()
+
+        return render_template(
+            "index.html",
+            **_index_context(
+                preview_notice=project["preview_notice"],
+                form_state=form_state,
+                project_id=project_id,
+            ),
+        )
+
+    solver = (form_state["solver"] or DEFAULT_SOLVER).lower()
     if solver not in {"cg", "sor"}:
         return redirect(url_for("index", error="Solver must be either CG or SOR."))
 
-    tol_raw = request.form.get("tol", str(DEFAULT_TOLERANCE))
     try:
-        tolerance = float(tol_raw)
+        tolerance = float(form_state["tol"])
     except ValueError:
         return redirect(url_for("index", error="Tolerance must be numeric."))
 
-    max_iters_raw = request.form.get("max_iters", str(DEFAULT_MAX_ITERS))
     try:
-        max_iters = int(max_iters_raw)
+        max_iters = int(form_state["max_iters"])
     except ValueError:
         return redirect(url_for("index", error="Max iterations must be an integer."))
 
-    outputs_value = (request.form.get("outputs") or "").strip()
-
-    suffix = Path(geometry.filename).suffix.lower()
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    safe_name = secure_filename(geometry.filename) or f"scenario_{timestamp}{suffix}"
-    scenario_path = Path(app.config["UPLOAD_FOLDER"]) / f"{timestamp}_{safe_name}"
-
-    if suffix == ".json":
-        scenario_path.parent.mkdir(parents=True, exist_ok=True)
-        geometry.save(scenario_path)
-        try:
-            json.loads(scenario_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            scenario_path.unlink(missing_ok=True)
-            return redirect(url_for("index", error="Uploaded JSON is invalid."))
-    else:
-        # DXF support is not yet implemented for the Flask prototype.
-        return redirect(url_for("index", error="DXF uploads are not supported yet."))
+    outputs_value = form_state["outputs"].strip()
 
     command = [
         "./build/motor_sim",
@@ -327,13 +764,26 @@ def upload() -> Response:
     if outputs_value:
         command.extend(["--outputs", outputs_value])
 
-    log_path = Path(app.config["RESULTS_FOLDER"]) / f"simulation_{timestamp}.log"
+    run_stamp = time.strftime("%Y%m%d-%H%M%S")
+    log_path = Path(app.config["RESULTS_FOLDER"]) / f"simulation_{run_stamp}.log"
+
+    field_outputs = _collect_field_outputs(spec, scenario_path.parent)
+    extra_downloads = [
+        {
+            "category": "result",
+            "path": str(entry["path"]),
+            "label": f"Field map CSV ({entry['id']})" if entry.get("id") else entry["path"].name,
+        }
+        for entry in field_outputs
+    ]
 
     try:
         manager.start(
             command,
             scenario_path=scenario_path,
             log_path=log_path,
+            extra_downloads=extra_downloads,
+            field_outputs=[{"id": entry.get("id"), "path": str(entry["path"])} for entry in field_outputs],
         )
     except RuntimeError as exc:
         return redirect(url_for("index", error=str(exc)))
@@ -388,6 +838,99 @@ def download() -> Response:
         abort(404)
 
     return send_file(file_path, as_attachment=True)
+
+
+@app.post("/project/reset")
+def project_reset() -> Response:
+    if manager.is_running:
+        return redirect(url_for("index", error="Stop the running simulation before clearing the project."))
+
+    project_id = session.pop("project_id", None)
+    if project_id:
+        _discard_project(project_id)
+
+    manager.clear_last_result()
+    return redirect(url_for("index", notice="Project cleared."))
+
+
+@app.get("/project/scenario")
+def project_scenario() -> Response:
+    project_id, project = _current_project()
+    if project is None:
+        abort(404)
+
+    scenario_path = project.get("scenario_path")
+    if not isinstance(scenario_path, Path) or not scenario_path.exists():
+        abort(404)
+
+    download_name = project.get("original_filename") or scenario_path.name
+    return send_file(scenario_path, as_attachment=True, download_name=download_name)
+
+
+@app.get("/result-image/<path:filename>")
+def result_image(filename: str) -> Response:
+    safe_name = secure_filename(filename)
+    if not safe_name:
+        abort(400)
+
+    file_path = Path(app.config["RESULTS_FOLDER"]) / safe_name
+    if not file_path.exists():
+        abort(404)
+
+    return send_file(file_path, mimetype="image/png")
+
+
+@app.get("/visualization.png")
+def visualization_image() -> Response:
+    last_result = manager.get_last_result()
+    scenario_path = Path(last_result.get("scenario_path", ""))
+    field_map_path = Path(last_result.get("field_map", ""))
+    if not scenario_path.exists() or not field_map_path.exists():
+        abort(404)
+
+    vector_mode = request.args.get("vector", DEFAULT_VECTOR_MODE)
+    if vector_mode not in {"linear", "log", "off"}:
+        abort(400)
+
+    try:
+        quiver_skip = int(request.args.get("skip", DEFAULT_QUIVER_SKIP))
+        if quiver_skip < 1:
+            raise ValueError
+    except ValueError:
+        abort(400)
+
+    color_scale = request.args.get("scale", DEFAULT_COLOR_SCALE)
+    if color_scale not in {"linear", "log"}:
+        abort(400)
+
+    draw_boundaries = request.args.get("boundaries", "1") != "0"
+    streamlines = request.args.get("stream", "0") == "1"
+
+    try:
+        log_floor_value = float(request.args.get("log_floor", DEFAULT_LOG_FLOOR))
+        vector_floor_value = float(request.args.get("vector_floor", DEFAULT_LOG_FLOOR))
+    except ValueError:
+        abort(400)
+
+    data = render_field_map_image(
+        scenario_path,
+        field_map_path,
+        output_path=None,
+        vector_mode=vector_mode,
+        quiver_skip=quiver_skip,
+        color_scale=color_scale,
+        draw_boundaries=draw_boundaries,
+        streamlines=streamlines,
+        log_floor=log_floor_value,
+        vector_log_floor=vector_floor_value,
+    )
+
+    if isinstance(data, Path):  # pragma: no cover - defensive guard
+        payload = data.read_bytes()
+    else:
+        payload = data
+
+    return Response(payload, mimetype="image/png")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution helper

--- a/python/gui/app_flask.py
+++ b/python/gui/app_flask.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 import queue
 import re
+import shutil
 import subprocess
 import threading
 import time
 import uuid
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -25,6 +27,13 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 
+from python.gui.dxf_utils import (
+    DxfError,
+    export_scenario_to_dxf,
+    load_primitives,
+    render_preview,
+    summarise_dxf,
+)
 from python.gui.render import (
     DEFAULT_LOG_FLOOR,
     render_field_map_image,
@@ -41,6 +50,15 @@ DEFAULT_VECTOR_MODE = "linear"
 DEFAULT_COLOR_SCALE = "linear"
 DEFAULT_QUIVER_SKIP = 4
 DEFAULT_STREAMLINES = False
+DXF_CATEGORY_OPTIONS = [
+    ("domain", "Domain boundary"),
+    ("material", "Material region"),
+    ("magnet", "Magnet region"),
+    ("wire", "Conductor path"),
+    ("structural", "Structural / reference"),
+    ("unassigned", "Unassigned"),
+]
+DXF_DEFAULT_CATEGORY = "unassigned"
 FIELD_MAP_REGEX = re.compile(
     r"Frame\\s+(?P<frame>\\d+):\\s+wrote\\s+field_map\\s+'(?P<id>[^']+)'\\s+to\\s+(?P<path>.+)"
 )
@@ -93,6 +111,7 @@ class SimulationManager:
                 "extra_downloads": extra_downloads or [],
                 "field_outputs": field_outputs or [],
                 "processed_field_maps": set(),
+                "process_cwd": Path.cwd(),
             }
             self._queue.put({
                 "started": True,
@@ -152,9 +171,13 @@ class SimulationManager:
         if not cleaned_path:
             return
 
-        output_path = Path(cleaned_path)
-        if not output_path.is_absolute():
-            output_path = scenario_path.parent / output_path
+        process_cwd: Optional[Path] = self._metadata.get("process_cwd")
+        scenario_dir = scenario_path.parent if scenario_path else None
+        output_path = _resolve_output_path(
+            Path(cleaned_path),
+            scenario_dir=scenario_dir,
+            process_cwd=process_cwd,
+        )
 
         if not output_path.exists():
             return
@@ -206,18 +229,26 @@ class SimulationManager:
     def _candidate_field_maps(self) -> List[Path]:
         scenario_path: Optional[Path] = self._metadata.get("scenario_path")
         scenario_dir = scenario_path.parent if scenario_path else None
+        process_cwd: Optional[Path] = self._metadata.get("process_cwd")
         candidates: List[Path] = []
+        seen: Set[Path] = set()
         latest = self._metadata.get("latest_field_map")
         if isinstance(latest, Path):
             candidates.append(latest)
+            seen.add(latest)
         for entry in self._metadata.get("field_outputs", []):
             path_value = entry.get("path")
             if not path_value:
                 continue
-            path = Path(path_value)
-            if not path.is_absolute() and scenario_dir is not None:
-                path = scenario_dir / path
+            path = _resolve_output_path(
+                Path(path_value),
+                scenario_dir=scenario_dir,
+                process_cwd=process_cwd,
+            )
+            if path in seen:
+                continue
             candidates.append(path)
+            seen.add(path)
         return candidates
 
     def _run_process(self, command: List[str]) -> None:
@@ -466,8 +497,96 @@ def _register_project(
         "preview_notice": None,
         "preview_version": None,
         "form_state": _build_form_state(),
+        "dxf_files": {},
+        "dxf_preview_path": None,
+        "dxf_preview_version": None,
+        "dxf_notice": None,
     }
     return project_id, PROJECTS[project_id]
+
+
+def _register_blank_project() -> Tuple[str, Dict[str, Any]]:
+    project_id = uuid.uuid4().hex
+    PROJECTS[project_id] = {
+        "scenario_path": None,
+        "spec": {},
+        "original_filename": None,
+        "scenario_name": None,
+        "created_label": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "preview_path": None,
+        "preview_notice": None,
+        "preview_version": None,
+        "form_state": _build_form_state(),
+        "dxf_files": {},
+        "dxf_preview_path": None,
+        "dxf_preview_version": None,
+        "dxf_notice": None,
+    }
+    return project_id, PROJECTS[project_id]
+
+
+def _ensure_project_for_dxf(project_id: Optional[str]) -> Tuple[str, Dict[str, Any]]:
+    active_id, project = _current_project(project_id)
+    if project is None:
+        active_id, project = _register_blank_project()
+    session["project_id"] = active_id
+    return active_id, project
+
+
+def _update_dxf_preview(project_id: str) -> None:
+    project = PROJECTS.get(project_id)
+    if not project:
+        return
+
+    preview_path = project.get("dxf_preview_path")
+    if isinstance(preview_path, Path):
+        preview_path.unlink(missing_ok=True)
+
+    primitives = []
+    dxf_store = project.get("dxf_files", {})
+    if isinstance(dxf_store, dict):
+        for entry in dxf_store.values():
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("path")
+            if not isinstance(path, Path) or not path.exists():
+                continue
+            layers = entry.get("layers", [])
+            if not isinstance(layers, list):
+                continue
+            selected_layers = [layer.get("name") for layer in layers if layer.get("selected")]
+            selected_layers = [name for name in selected_layers if isinstance(name, str) and name]
+            if not selected_layers:
+                continue
+            categories = {
+                layer.get("name"): layer.get("category") or DXF_DEFAULT_CATEGORY
+                for layer in layers
+                if isinstance(layer, dict) and layer.get("name")
+            }
+            try:
+                primitives.extend(load_primitives(path, selected_layers, categories))
+            except DxfError as exc:
+                project["dxf_notice"] = str(exc)
+                return
+
+    if not primitives:
+        project["dxf_preview_path"] = None
+        project["dxf_preview_version"] = None
+        project["dxf_notice"] = "Select DXF layers to preview."
+        return
+
+    output_name = f"dxf_preview_{project_id}_{time.strftime('%Y%m%d-%H%M%S')}"
+    preview_destination = Path(app.config["RESULTS_FOLDER"]) / f"{output_name}.png"
+    try:
+        render_preview(primitives, preview_destination)
+    except DxfError as exc:
+        project["dxf_notice"] = str(exc)
+        preview_destination.unlink(missing_ok=True)
+        return
+
+    project["dxf_preview_path"] = preview_destination
+    project["dxf_preview_version"] = time.time()
+    project["dxf_notice"] = None
 
 
 def _discard_project(project_id: str) -> None:
@@ -479,9 +598,20 @@ def _discard_project(project_id: str) -> None:
     if isinstance(preview_path, Path):
         preview_path.unlink(missing_ok=True)
 
+    dxf_preview_path = project.get("dxf_preview_path")
+    if isinstance(dxf_preview_path, Path):
+        dxf_preview_path.unlink(missing_ok=True)
+
     scenario_path = project.get("scenario_path")
     if isinstance(scenario_path, Path):
         scenario_path.unlink(missing_ok=True)
+
+    dxf_files = project.get("dxf_files", {})
+    if isinstance(dxf_files, dict):
+        for entry in dxf_files.values():
+            path = entry.get("path")
+            if isinstance(path, Path):
+                path.unlink(missing_ok=True)
 
 
 def _current_project(
@@ -555,13 +685,67 @@ def _index_context(
                 visualization_defaults[key] = settings[key]
 
     project_summary = None
+    project_has_scenario = False
+    dxf_files_summary: List[Dict[str, Any]] = []
+    dxf_preview_url = None
+    dxf_preview_token = None
+    dxf_notice = None
+    has_dxf_selection = False
+
     if project and active_id:
+        scenario_path_value = project.get("scenario_path")
+        scenario_exists = isinstance(scenario_path_value, Path) and scenario_path_value.exists()
+        project_has_scenario = scenario_exists
         project_summary = {
             "id": active_id,
             "filename": project.get("original_filename"),
             "scenario_name": project.get("scenario_name"),
             "created_label": project.get("created_label"),
+            "has_scenario": scenario_exists,
         }
+
+        dxf_store = project.get("dxf_files", {})
+        if isinstance(dxf_store, dict):
+            for dxf_id, entry in dxf_store.items():
+                if not isinstance(entry, dict):
+                    continue
+                layers_payload: List[Dict[str, Any]] = []
+                for layer in entry.get("layers", []):
+                    if not isinstance(layer, dict):
+                        continue
+                    category_value = layer.get("category") or DXF_DEFAULT_CATEGORY
+                    selected_value = bool(layer.get("selected", False))
+                    layers_payload.append(
+                        {
+                            "form_id": layer.get("form_id"),
+                            "name": layer.get("name"),
+                            "entity_count": layer.get("entity_count", 0),
+                            "types": layer.get("types", []),
+                            "selected": selected_value,
+                            "category": category_value,
+                        }
+                    )
+                    has_dxf_selection = has_dxf_selection or selected_value
+                layers_payload.sort(key=lambda item: (item["name"] or "").lower())
+                entry_path = entry.get("path")
+                display_name = entry.get("original_name") or entry.get("name")
+                if not display_name and isinstance(entry_path, Path):
+                    display_name = entry_path.name
+                dxf_files_summary.append(
+                    {
+                        "id": dxf_id,
+                        "name": display_name or dxf_id,
+                        "layers": layers_payload,
+                        "uploaded_label": entry.get("uploaded_label"),
+                    }
+                )
+            dxf_files_summary.sort(key=lambda item: item["name"].lower())
+
+        preview_path = project.get("dxf_preview_path")
+        if isinstance(preview_path, Path) and preview_path.exists():
+            dxf_preview_url = url_for("result_image", filename=preview_path.name)
+            dxf_preview_token = project.get("dxf_preview_version")
+        dxf_notice = project.get("dxf_notice")
 
     return {
         "running": manager.is_running,
@@ -579,9 +763,17 @@ def _index_context(
         "DEFAULT_LOG_FLOOR": DEFAULT_LOG_FLOOR,
         "project": project_summary,
         "has_project": project_summary is not None,
-        "project_download_url": url_for("project_scenario") if project_summary else None,
-        "form_requires_file": project_summary is None,
+        "project_download_url": url_for("project_scenario") if project_has_scenario else None,
+        "project_export_dxf_url": url_for("project_export_dxf") if project_has_scenario else None,
+        "project_has_scenario": project_has_scenario,
+        "form_requires_file": not project_has_scenario,
         "status_message": status_message,
+        "dxf_files": dxf_files_summary,
+        "dxf_preview_url": dxf_preview_url,
+        "dxf_preview_token": dxf_preview_token,
+        "dxf_notice": dxf_notice,
+        "dxf_categories": DXF_CATEGORY_OPTIONS,
+        "has_dxf_selection": has_dxf_selection,
     }
 
 
@@ -602,6 +794,28 @@ def _store_scenario_file(geometry) -> Tuple[Path, dict, str, str]:
     return scenario_path, spec, timestamp, original_name
 
 
+def _resolve_output_path(
+    raw_path: Path, *, scenario_dir: Optional[Path], process_cwd: Optional[Path]
+) -> Path:
+    if raw_path.is_absolute():
+        return raw_path
+
+    candidates: List[Path] = []
+    if scenario_dir is not None:
+        candidates.append(scenario_dir / raw_path)
+    if process_cwd is not None:
+        candidates.append(process_cwd / raw_path)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    if candidates:
+        return candidates[0]
+
+    return raw_path
+
+
 def _collect_field_outputs(spec: dict, scenario_dir: Path) -> List[Dict[str, Any]]:
     outputs: List[Dict[str, Any]] = []
     for entry in spec.get("outputs", []):
@@ -613,11 +827,151 @@ def _collect_field_outputs(spec: dict, scenario_dir: Path) -> List[Dict[str, Any
             path_value = f"outputs/{identifier}.csv"
         if not path_value:
             continue
-        path = Path(path_value)
-        if not path.is_absolute():
-            path = scenario_dir / path
-        outputs.append({"id": identifier, "path": path})
+        raw_path = Path(path_value)
+        resolved = _resolve_output_path(
+            raw_path, scenario_dir=scenario_dir, process_cwd=Path.cwd()
+        )
+        outputs.append({"id": identifier, "path": resolved})
     return outputs
+
+
+@app.post("/dxf/upload")
+def upload_dxf_files() -> Response:
+    project_hint = request.form.get("project_id")
+    project_id, project = _ensure_project_for_dxf(project_hint)
+
+    files = request.files.getlist("dxf_files")
+    if not files or all(not f.filename for f in files):
+        return redirect(url_for("index", error="Select at least one DXF file to import."))
+
+    errors: List[str] = []
+    imported = 0
+    dxf_store = project.setdefault("dxf_files", {})
+
+    for storage in files:
+        if not storage.filename:
+            continue
+        suffix = Path(storage.filename).suffix.lower()
+        if suffix != ".dxf":
+            errors.append(f"Unsupported extension for {storage.filename}; only DXF files are allowed.")
+            continue
+
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        safe_name = secure_filename(storage.filename) or f"drawing_{timestamp}.dxf"
+        destination = Path(app.config["UPLOAD_FOLDER"]) / f"{project_id}_{timestamp}_{safe_name}"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        storage.save(destination)
+
+        try:
+            layer_summary = summarise_dxf(destination)
+        except DxfError as exc:
+            destination.unlink(missing_ok=True)
+            errors.append(str(exc))
+            continue
+
+        if not layer_summary:
+            destination.unlink(missing_ok=True)
+            errors.append(f"{storage.filename} does not contain supported geometry.")
+            continue
+
+        entry_id = uuid.uuid4().hex
+        dxf_store[entry_id] = {
+            "id": entry_id,
+            "path": destination,
+            "original_name": storage.filename,
+            "uploaded_label": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "layers": [
+                {
+                    "name": info.name,
+                    "entity_count": info.entity_count,
+                    "types": list(info.types),
+                    "selected": True,
+                    "category": DXF_DEFAULT_CATEGORY,
+                    "form_id": uuid.uuid4().hex[:8],
+                }
+                for info in layer_summary
+            ],
+        }
+        imported += 1
+
+    notice = None
+    if imported:
+        _update_dxf_preview(project_id)
+        project["dxf_notice"] = None
+        notice = f"Imported {imported} DXF file{'s' if imported != 1 else ''}."
+
+    if errors:
+        project["dxf_notice"] = errors[0]
+        if not imported:
+            return redirect(url_for("index", error=errors[0]))
+        if notice:
+            return redirect(url_for("index", notice=f"{notice} Some files could not be processed."))
+        return redirect(url_for("index", notice="Some DXF files could not be processed."))
+
+    if notice:
+        return redirect(url_for("index", notice=notice))
+
+    return redirect(url_for("index"))
+
+
+@app.post("/dxf/<dxf_id>/layers")
+def configure_dxf_layers(dxf_id: str) -> Response:
+    project_hint = request.form.get("project_id")
+    active_id, project = _current_project(project_hint)
+    if not project or not active_id:
+        return redirect(url_for("index", error="Project not found."))
+
+    session["project_id"] = active_id
+    dxf_store = project.get("dxf_files", {})
+    entry = dxf_store.get(dxf_id) if isinstance(dxf_store, dict) else None
+    if entry is None:
+        return redirect(url_for("index", error="DXF entry not found."))
+
+    valid_categories = {choice[0] for choice in DXF_CATEGORY_OPTIONS}
+    layers = entry.get("layers", [])
+    if isinstance(layers, list):
+        for layer in layers:
+            if not isinstance(layer, dict):
+                continue
+            form_id = layer.get("form_id")
+            if not form_id:
+                continue
+            selected = request.form.get(f"layer-{form_id}-selected") == "on"
+            category = request.form.get(f"layer-{form_id}-category") or DXF_DEFAULT_CATEGORY
+            if category not in valid_categories:
+                category = DXF_DEFAULT_CATEGORY
+            layer["selected"] = selected
+            layer["category"] = category
+
+    project["dxf_notice"] = None
+    _update_dxf_preview(active_id)
+
+    return redirect(url_for("index", notice="DXF layers updated."))
+
+
+@app.post("/dxf/<dxf_id>/delete")
+def delete_dxf_entry(dxf_id: str) -> Response:
+    project_hint = request.form.get("project_id")
+    active_id, project = _current_project(project_hint)
+    if not project or not active_id:
+        return redirect(url_for("index", error="Project not found."))
+
+    session["project_id"] = active_id
+    dxf_store = project.get("dxf_files", {})
+    entry = None
+    if isinstance(dxf_store, dict):
+        entry = dxf_store.pop(dxf_id, None)
+
+    if isinstance(entry, dict):
+        path = entry.get("path")
+        if isinstance(path, Path):
+            path.unlink(missing_ok=True)
+        project["dxf_notice"] = None
+        _update_dxf_preview(active_id)
+        return redirect(url_for("index", notice="Removed DXF file."))
+
+    _update_dxf_preview(active_id)
+    return redirect(url_for("index", error="DXF entry not found."))
 
 
 @app.get("/")
@@ -651,7 +1005,7 @@ def upload() -> Response:
 
         suffix = Path(geometry.filename).suffix.lower()
         if suffix != ".json":
-            return redirect(url_for("index", error="DXF uploads are not supported yet."))
+            return redirect(url_for("index", error="Import DXF files via the CAD workspace."))
 
         if current_project_id and current_project_id in PROJECTS:
             _discard_project(current_project_id)
@@ -865,6 +1219,35 @@ def project_scenario() -> Response:
 
     download_name = project.get("original_filename") or scenario_path.name
     return send_file(scenario_path, as_attachment=True, download_name=download_name)
+
+
+@app.get("/project/export_dxf")
+def project_export_dxf() -> Response:
+    project_id, project = _current_project()
+    if project is None:
+        abort(404)
+
+    scenario_path = project.get("scenario_path")
+    if not isinstance(scenario_path, Path) or not scenario_path.exists():
+        return redirect(url_for("index", error="Load a scenario before exporting DXF geometry."))
+
+    export_root = Path(app.config["RESULTS_FOLDER"]) / f"dxf_export_{uuid.uuid4().hex}"
+    try:
+        exported_paths = export_scenario_to_dxf(scenario_path, export_root)
+    except DxfError as exc:
+        shutil.rmtree(export_root, ignore_errors=True)
+        return redirect(url_for("index", error=str(exc)))
+
+    if not exported_paths:
+        shutil.rmtree(export_root, ignore_errors=True)
+        return redirect(url_for("index", error="Scenario does not contain exportable geometry."))
+
+    archive_path = export_root / f"{scenario_path.stem}_geometry.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for item in exported_paths:
+            archive.write(item, arcname=item.name)
+
+    return send_file(archive_path, as_attachment=True, download_name=archive_path.name)
 
 
 @app.get("/result-image/<path:filename>")

--- a/python/gui/dxf_utils.py
+++ b/python/gui/dxf_utils.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import ezdxf
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.patches import Circle  # noqa: E402
+
+
+class DxfError(RuntimeError):
+    """Raised when DXF artefacts cannot be processed."""
+
+
+@dataclass
+class DxfLayerInfo:
+    name: str
+    entity_count: int
+    types: Sequence[str]
+
+
+@dataclass
+class DxfPrimitive:
+    kind: str
+    points: Sequence[Tuple[float, float]] | None = None
+    center: Tuple[float, float] | None = None
+    radius: float | None = None
+    layer: str = "0"
+    category: Optional[str] = None
+
+
+_CATEGORY_COLOURS = {
+    "domain": "#0d6efd",
+    "material": "#198754",
+    "magnet": "#d63384",
+    "wire": "#fd7e14",
+    "structural": "#20c997",
+    "unassigned": "#6c757d",
+}
+
+
+def summarise_dxf(path: Path) -> List[DxfLayerInfo]:
+    """Return basic layer statistics for the supplied DXF file."""
+
+    try:
+        doc = ezdxf.readfile(str(path))
+    except (OSError, ezdxf.DXFStructureError, ezdxf.DXFTableEntryError) as exc:
+        raise DxfError(f"Failed to read DXF '{path.name}': {exc}") from exc
+
+    counts: Dict[str, int] = {}
+    types: Dict[str, set[str]] = {}
+
+    for entity in doc.modelspace():
+        layer = entity.dxf.layer or "0"
+        counts[layer] = counts.get(layer, 0) + 1
+        types.setdefault(layer, set()).add(entity.dxftype())
+
+    summary: List[DxfLayerInfo] = []
+    for layer, count in sorted(counts.items()):
+        summary.append(DxfLayerInfo(name=layer, entity_count=count, types=sorted(types[layer])))
+
+    return summary
+
+
+def _polyline_points(entity) -> List[Tuple[float, float]]:
+    if entity.dxftype() == "LWPOLYLINE":
+        return [(pt[0], pt[1]) for pt in entity.get_points("xy")]
+    if entity.dxftype() == "POLYLINE":
+        return [(v.dxf.location.x, v.dxf.location.y) for v in entity.vertices()]
+    if entity.dxftype() == "LINE":
+        return [
+            (float(entity.dxf.start.x), float(entity.dxf.start.y)),
+            (float(entity.dxf.end.x), float(entity.dxf.end.y)),
+        ]
+    return []
+
+
+def load_primitives(path: Path, layers: Iterable[str], categories: Dict[str, Optional[str]]) -> List[DxfPrimitive]:
+    """Extract drawable primitives for the requested layers."""
+
+    selected = {layer.lower() for layer in layers}
+    if not selected:
+        return []
+
+    try:
+        doc = ezdxf.readfile(str(path))
+    except (OSError, ezdxf.DXFStructureError, ezdxf.DXFTableEntryError) as exc:
+        raise DxfError(f"Failed to read DXF '{path.name}': {exc}") from exc
+
+    primitives: List[DxfPrimitive] = []
+    for entity in doc.modelspace():
+        layer = (entity.dxf.layer or "0")
+        if layer.lower() not in selected:
+            continue
+
+        category = categories.get(layer)
+        if entity.dxftype() in {"LWPOLYLINE", "POLYLINE", "LINE"}:
+            points = _polyline_points(entity)
+            if not points:
+                continue
+            primitives.append(DxfPrimitive(kind="polyline", points=points, layer=layer, category=category))
+        elif entity.dxftype() == "CIRCLE":
+            center = (float(entity.dxf.center.x), float(entity.dxf.center.y))
+            primitives.append(
+                DxfPrimitive(
+                    kind="circle",
+                    center=center,
+                    radius=float(entity.dxf.radius),
+                    layer=layer,
+                    category=category,
+                )
+            )
+
+    return primitives
+
+
+def render_preview(primitives: Sequence[DxfPrimitive], output_path: Path) -> Path:
+    """Render DXF primitives into an image."""
+
+    if not primitives:
+        raise DxfError("No DXF layers selected for preview.")
+
+    xmin = math.inf
+    xmax = -math.inf
+    ymin = math.inf
+    ymax = -math.inf
+
+    for primitive in primitives:
+        if primitive.kind == "polyline" and primitive.points:
+            xs, ys = zip(*primitive.points)
+            xmin = min(xmin, min(xs))
+            xmax = max(xmax, max(xs))
+            ymin = min(ymin, min(ys))
+            ymax = max(ymax, max(ys))
+        elif primitive.kind == "circle" and primitive.center and primitive.radius is not None:
+            cx, cy = primitive.center
+            r = primitive.radius
+            xmin = min(xmin, cx - r)
+            xmax = max(xmax, cx + r)
+            ymin = min(ymin, cy - r)
+            ymax = max(ymax, cy + r)
+
+    if not math.isfinite(xmin) or not math.isfinite(xmax) or xmin == xmax or ymin == ymax:
+        xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
+
+    padding_x = max(0.05 * (xmax - xmin), 1e-3)
+    padding_y = max(0.05 * (ymax - ymin), 1e-3)
+    xmin -= padding_x
+    xmax += padding_x
+    ymin -= padding_y
+    ymax += padding_y
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    colour_cache: Dict[str, str] = {}
+
+    for primitive in primitives:
+        category = primitive.category or "unassigned"
+        colour = colour_cache.get(category)
+        if colour is None:
+            colour = _CATEGORY_COLOURS.get(category, _CATEGORY_COLOURS["unassigned"])
+            colour_cache[category] = colour
+
+        if primitive.kind == "polyline" and primitive.points:
+            xs, ys = zip(*primitive.points)
+            ax.plot(xs, ys, color=colour, linewidth=1.2)
+        elif primitive.kind == "circle" and primitive.center and primitive.radius is not None:
+            circle = Circle(primitive.center, primitive.radius, fill=False, linewidth=1.2, color=colour)
+            ax.add_patch(circle)
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlim(xmin, xmax)
+    ax.set_ylim(ymin, ymax)
+    ax.axis("off")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight", pad_inches=0.05)
+    plt.close(fig)
+    return output_path
+
+
+def export_scenario_to_dxf(scenario_path: Path, output_dir: Path) -> List[Path]:
+    """Convert a scenario JSON into a set of DXF artefacts."""
+
+    from python.visualize_scenario_field import compute_domain_bounds, gather_boundaries, load_scenario
+
+    spec, wires = load_scenario(scenario_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    exported: List[Path] = []
+
+    # Domain boundary
+    try:
+        xmin, xmax, ymin, ymax = compute_domain_bounds(spec)
+    except ValueError as exc:
+        raise DxfError(str(exc)) from exc
+
+    domain_doc = ezdxf.new("R2010")
+    msp = domain_doc.modelspace()
+    msp.add_lwpolyline(
+        [(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax), (xmin, ymin)],
+        dxfattribs={"layer": "domain"},
+    )
+    domain_path = output_dir / "domain.dxf"
+    domain_doc.saveas(domain_path)
+    exported.append(domain_path)
+
+    # Material regions
+    boundaries = gather_boundaries(spec)
+    region_doc = ezdxf.new("R2010")
+    region_msp = region_doc.modelspace()
+    for index, (xs, ys, material) in enumerate(boundaries.get("polygons", [])):
+        if len(xs) < 2:
+            continue
+        coords = list(zip(xs, ys))
+        if coords[0] != coords[-1]:
+            coords.append(coords[0])
+        layer_name = f"material_{material or index}"
+        region_msp.add_lwpolyline(coords, dxfattribs={"layer": layer_name})
+    if len(region_msp):
+        regions_path = output_dir / "materials.dxf"
+        region_doc.saveas(regions_path)
+        exported.append(regions_path)
+
+    magnet_doc = ezdxf.new("R2010")
+    magnet_msp = magnet_doc.modelspace()
+    for idx, (xs, ys) in enumerate(boundaries.get("magnet_polygons", [])):
+        if len(xs) < 2:
+            continue
+        coords = list(zip(xs, ys))
+        if coords[0] != coords[-1]:
+            coords.append(coords[0])
+        magnet_msp.add_lwpolyline(coords, dxfattribs={"layer": f"magnet_{idx}"})
+    for idx, rect in enumerate(boundaries.get("magnet_rects", [])):
+        xmin_r, xmax_r, ymin_r, ymax_r = rect
+        coords = [
+            (xmin_r, ymin_r),
+            (xmax_r, ymin_r),
+            (xmax_r, ymax_r),
+            (xmin_r, ymax_r),
+            (xmin_r, ymin_r),
+        ]
+        magnet_msp.add_lwpolyline(coords, dxfattribs={"layer": f"magnet_rect_{idx}"})
+    if len(magnet_msp):
+        magnets_path = output_dir / "magnets.dxf"
+        magnet_doc.saveas(magnets_path)
+        exported.append(magnets_path)
+
+    if wires:
+        wire_doc = ezdxf.new("R2010")
+        wire_msp = wire_doc.modelspace()
+        for idx, wire in enumerate(wires):
+            wire_msp.add_circle(
+                center=(wire.x, wire.y),
+                radius=wire.radius,
+                dxfattribs={"layer": f"wire_{idx}"},
+            )
+        wires_path = output_dir / "wires.dxf"
+        wire_doc.saveas(wires_path)
+        exported.append(wires_path)
+
+    return exported

--- a/python/gui/render.py
+++ b/python/gui/render.py
@@ -1,0 +1,142 @@
+"""Helpers for rendering geometry previews and field visualisations."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt  # noqa: E402  - backend configured above
+from matplotlib.patches import Rectangle  # noqa: E402
+
+from python.visualize_scenario_field import (  # noqa: E402
+    Wire,
+    compute_domain_bounds,
+    gather_boundaries,
+    load_field_csv,
+    load_scenario,
+    plot_field,
+    reshape_field,
+)
+
+
+DEFAULT_LOG_FLOOR = 1e-7
+
+
+def render_geometry_preview(scenario_path: Path, output_path: Path) -> Path:
+    """Render a static geometry preview for the supplied scenario."""
+
+    spec, wires = load_scenario(scenario_path)
+    boundaries = {}
+    try:
+        boundaries = gather_boundaries(spec)
+        xmin, xmax, ymin, ymax = compute_domain_bounds(spec)
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    fig, ax = plt.subplots(figsize=(6.0, 5.0))
+
+    width = xmax - xmin
+    height = ymax - ymin
+    rect = Rectangle((xmin, ymin), width, height, fill=False, linewidth=1.6)
+    ax.add_patch(rect)
+
+    for xs, ys, _material in boundaries.get("polygons", []):
+        if len(xs) < 2:
+            continue
+        closed_xs = xs + [xs[0]]
+        closed_ys = ys + [ys[0]]
+        ax.plot(closed_xs, closed_ys, color="tab:blue", linestyle="-", linewidth=1.0, alpha=0.7)
+
+    for xs, ys in boundaries.get("magnet_polygons", []):
+        if len(xs) < 2:
+            continue
+        closed_xs = xs + [xs[0]]
+        closed_ys = ys + [ys[0]]
+        ax.plot(closed_xs, closed_ys, color="tab:red", linestyle=":", linewidth=1.2, alpha=0.9)
+
+    for xmin_m, xmax_m, ymin_m, ymax_m in boundaries.get("magnet_rects", []):
+        rect_x = [xmin_m, xmax_m, xmax_m, xmin_m, xmin_m]
+        rect_y = [ymin_m, ymin_m, ymax_m, ymax_m, ymin_m]
+        ax.plot(rect_x, rect_y, color="tab:red", linestyle=":", linewidth=1.1, alpha=0.9)
+
+    for wire in wires:
+        color = "tab:red" if wire.current >= 0 else "tab:blue"
+        circle = plt.Circle((wire.x, wire.y), wire.radius, color=color, fill=False, linewidth=1.3)
+        ax.add_patch(circle)
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("x [m]")
+    ax.set_ylabel("y [m]")
+    ax.set_title(spec.get("name", scenario_path.name))
+    ax.set_xlim(xmin, xmax)
+    ax.set_ylim(ymin, ymax)
+    ax.grid(False)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def render_field_map_image(
+    scenario_path: Path,
+    field_map_path: Path,
+    *,
+    output_path: Optional[Path] = None,
+    vector_mode: str = "linear",
+    quiver_skip: int = 4,
+    color_scale: str = "linear",
+    draw_boundaries: bool = True,
+    streamlines: bool = False,
+    log_floor: float = DEFAULT_LOG_FLOOR,
+    vector_log_floor: float = DEFAULT_LOG_FLOOR,
+) -> bytes | Path:
+    """Render the field map with the supplied styling options."""
+
+    spec, wires = load_scenario(scenario_path)
+    xs, ys, bxs, bys, bmags = load_field_csv(field_map_path)
+    grid_x, grid_y, (bx, by, bmag) = reshape_field(xs, ys, (bxs, bys, bmags))
+
+    boundaries: Dict[str, List] = {}
+    if draw_boundaries:
+        try:
+            boundaries = gather_boundaries(spec)
+        except ValueError:
+            boundaries = {}
+
+    buffer = io.BytesIO()
+    plot_field(
+        grid_x,
+        grid_y,
+        bx,
+        by,
+        bmag,
+        wires,
+        quiver_skip,
+        buffer,
+        f"Field map: {scenario_path.name}",
+        color_scale,
+        log_floor,
+        draw_boundaries,
+        boundaries,
+        None,
+        vector_mode,
+        vector_log_floor,
+        streamlines,
+        None,
+        0,
+        show=False,
+    )
+
+    data = buffer.getvalue()
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(data)
+        return output_path
+
+    return data

--- a/python/gui/templates/base.html
+++ b/python/gui/templates/base.html
@@ -3,24 +3,139 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>mag_sim Flask GUI</title>
+    <title>mag_sim Studio</title>
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
       crossorigin="anonymous"
     >
+    <style>
+      body {
+        background-color: #f5f7fb;
+        min-height: 100vh;
+      }
+
+      .app-topbar {
+        --bs-navbar-padding-y: 0.5rem;
+      }
+
+      .app-shell {
+        min-height: calc(100vh - 60px);
+      }
+
+      .app-sidebar {
+        width: 260px;
+        background-color: #fff;
+      }
+
+      .app-sidebar .nav-link {
+        border-radius: 0.5rem;
+      }
+
+      .app-sidebar .nav-link.active {
+        background-color: #0d6efd;
+        color: #fff;
+      }
+
+      .app-content {
+        flex: 1;
+        padding: 2rem 3rem;
+      }
+
+      @media (max-width: 992px) {
+        .app-shell {
+          flex-direction: column;
+        }
+
+        .app-sidebar {
+          width: 100%;
+          border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+        }
+
+        .app-content {
+          padding: 1.5rem 1rem;
+        }
+      }
+
+      .stage-section + .stage-section {
+        margin-top: 2rem;
+      }
+
+      .card-elevated {
+        box-shadow: 0 0.5rem 1.2rem rgba(15, 23, 42, 0.08);
+        border: none;
+      }
+    </style>
     {% block head %}{% endblock %}
   </head>
-  <body class="bg-light">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom shadow-sm app-topbar">
       <div class="container-fluid">
-        <a class="navbar-brand" href="{{ url_for('index') }}">mag_sim GUI</a>
+        <a class="navbar-brand fw-semibold" href="{{ url_for('index') }}">mag_sim Studio</a>
+        <div class="d-flex align-items-center gap-3">
+          <div class="text-muted small d-none d-md-block">
+            {% if project %}
+              <span class="fw-semibold">Project:</span>
+              {{ project.scenario_name or project.filename }}
+            {% else %}
+              <span class="fw-semibold">Project:</span>
+              <em>No scenario loaded</em>
+            {% endif %}
+          </div>
+          <div class="dropdown">
+            <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">File</button>
+            <ul class="dropdown-menu dropdown-menu-end shadow">
+              <li>
+                <form method="post" action="{{ url_for('project_reset') }}" class="dropdown-item p-0">
+                  <button class="dropdown-item" type="submit" {% if running %}disabled{% endif %}>New project</button>
+                </form>
+              </li>
+              <li>
+                {% if has_project %}
+                  <a class="dropdown-item" href="{{ project_download_url }}">Save scenario…</a>
+                {% else %}
+                  <span class="dropdown-item disabled">Save scenario…</span>
+                {% endif %}
+              </li>
+            </ul>
+          </div>
+          <div class="dropdown">
+            <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Help</button>
+            <ul class="dropdown-menu dropdown-menu-end shadow">
+              <li>
+                <a class="dropdown-item" href="https://github.com/mag-co/mag_sim/blob/main/docs/user-guide/gui_flask.md" target="_blank" rel="noopener">Documentation</a>
+              </li>
+              <li>
+                <span class="dropdown-item disabled">Keyboard shortcuts (coming soon)</span>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </nav>
-    <main class="container mb-5">
-      {% block content %}{% endblock %}
-    </main>
+    <div class="app-shell d-flex">
+      <aside class="app-sidebar border-end">
+        <div class="p-3">
+          <div class="text-uppercase text-muted small mb-3">Workflow</div>
+          <nav class="nav flex-column gap-2">
+            <a class="nav-link" href="#project-overview">Workspace summary</a>
+            <a class="nav-link" href="#geometry-preview">Geometry preview</a>
+            <a class="nav-link" href="#simulation-setup">Simulation setup</a>
+            <a class="nav-link" href="#progress-stage">Progress &amp; logs</a>
+            <a class="nav-link" href="#results-stage">Results &amp; visuals</a>
+          </nav>
+        </div>
+      </aside>
+      <main class="app-content">
+        {% block content %}{% endblock %}
+      </main>
+    </div>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
     {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/python/gui/templates/base.html
+++ b/python/gui/templates/base.html
@@ -22,11 +22,17 @@
 
       .app-shell {
         min-height: calc(100vh - 60px);
+        align-items: flex-start;
       }
 
       .app-sidebar {
         width: 260px;
         background-color: #fff;
+        position: sticky;
+        top: 60px;
+        align-self: flex-start;
+        max-height: calc(100vh - 60px);
+        overflow-y: auto;
       }
 
       .app-sidebar .nav-link {
@@ -51,6 +57,9 @@
         .app-sidebar {
           width: 100%;
           border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+          position: static;
+          max-height: none;
+          overflow: visible;
         }
 
         .app-content {
@@ -98,13 +107,23 @@
                   <span class="dropdown-item disabled">Save scenario…</span>
                 {% endif %}
               </li>
+              <li>
+                {% if project_export_dxf_url %}
+                  <a class="dropdown-item" href="{{ project_export_dxf_url }}">Export DXF set…</a>
+                {% else %}
+                  <span class="dropdown-item disabled">Export DXF set…</span>
+                {% endif %}
+              </li>
             </ul>
           </div>
           <div class="dropdown">
             <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Help</button>
             <ul class="dropdown-menu dropdown-menu-end shadow">
               <li>
-                <a class="dropdown-item" href="https://github.com/mag-co/mag_sim/blob/main/docs/user-guide/gui_flask.md" target="_blank" rel="noopener">Documentation</a>
+                <a class="dropdown-item" href="https://lpurdy01.github.io/mag_sim/user-guide/gui_flask/" target="_blank" rel="noopener">GUI documentation</a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="https://lpurdy01.github.io/mag_sim/" target="_blank" rel="noopener">Documentation hub</a>
               </li>
               <li>
                 <span class="dropdown-item disabled">Keyboard shortcuts (coming soon)</span>
@@ -120,6 +139,7 @@
           <div class="text-uppercase text-muted small mb-3">Workflow</div>
           <nav class="nav flex-column gap-2">
             <a class="nav-link" href="#project-overview">Workspace summary</a>
+            <a class="nav-link" href="#cad-imports">CAD workspace</a>
             <a class="nav-link" href="#geometry-preview">Geometry preview</a>
             <a class="nav-link" href="#simulation-setup">Simulation setup</a>
             <a class="nav-link" href="#progress-stage">Progress &amp; logs</a>

--- a/python/gui/templates/index.html
+++ b/python/gui/templates/index.html
@@ -1,64 +1,259 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-lg-8">
-      <h1 class="mb-3">Run a Simulation</h1>
-      <p class="text-muted">Upload a scenario JSON, select solver options, and monitor progress in real time.</p>
-      {% if error %}
-        <div class="alert alert-danger" role="alert">
-          {{ error }}
-        </div>
-      {% endif %}
-      <form id="run-form" class="card card-body mb-3" method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data">
-        <div class="mb-3">
-          <label class="form-label" for="geometry-file">Scenario file (JSON)</label>
-          <input class="form-control" type="file" id="geometry-file" name="geometry_file" accept=".json,.dxf" required>
-          <div class="form-text">DXF uploads are reserved for a future update; please use JSON scenarios for now.</div>
-        </div>
-        <div class="row g-3">
-          <div class="col-md-4">
-            <label class="form-label" for="solver">Solver</label>
-            <select class="form-select" id="solver" name="solver">
-              <option value="cg" {% if default_solver == 'cg' %}selected{% endif %}>Conjugate Gradient (CG)</option>
-              <option value="sor" {% if default_solver == 'sor' %}selected{% endif %}>Successive Over-Relaxation (SOR)</option>
-            </select>
+  <section id="project-overview" class="stage-section">
+    <div class="row g-4">
+      <div class="col-xl-8">
+        <div class="card card-elevated h-100">
+          <div class="card-body">
+            <h5 class="card-title">Workspace summary</h5>
+            <p class="text-muted mb-4">Keep track of the active scenario and overall project state.</p>
+            {% if status_message %}
+              <div class="alert alert-info" role="alert">{{ status_message }}</div>
+            {% endif %}
+            {% if has_project %}
+              <dl class="row small mb-0">
+                <dt class="col-sm-4 text-uppercase text-muted">Scenario name</dt>
+                <dd class="col-sm-8">{{ project.scenario_name or 'Unnamed scenario' }}</dd>
+                <dt class="col-sm-4 text-uppercase text-muted">Source file</dt>
+                <dd class="col-sm-8">{{ project.filename }}</dd>
+                <dt class="col-sm-4 text-uppercase text-muted">Created</dt>
+                <dd class="col-sm-8">{{ project.created_label }}</dd>
+                <dt class="col-sm-4 text-uppercase text-muted">Next steps</dt>
+                <dd class="col-sm-8">Preview the geometry or adjust solver settings before running the simulation.</dd>
+              </dl>
+            {% else %}
+              <p class="mb-3">Start a new project by uploading a scenario JSON file in the <strong>Simulation setup</strong> section. The File menu can be used to clear or export the active scenario.</p>
+              <ul class="text-muted small mb-0">
+                <li>Preview the geometry to ensure regions, magnets, and conductors look correct.</li>
+                <li>Adjust solver tolerances and iteration caps as needed.</li>
+                <li>Watch the live progress and log stream to monitor convergence.</li>
+              </ul>
+            {% endif %}
           </div>
-          <div class="col-md-4">
-            <label class="form-label" for="tol">Tolerance</label>
-            <input class="form-control" type="number" step="any" id="tol" name="tol" value="{{ default_tolerance }}" required>
+        </div>
+      </div>
+      <div class="col-xl-4">
+        <div class="card card-elevated h-100">
+          <div class="card-body">
+            <h6 class="text-uppercase text-muted mb-3">Coming soon</h6>
+            <p class="small text-muted">Stage&nbsp;2 of the overhaul will unlock more analysis tools. Placeholders are provided so future controls have a home.</p>
+            <div class="d-grid gap-2">
+              <button class="btn btn-outline-secondary" type="button" disabled>DXF import</button>
+              <button class="btn btn-outline-secondary" type="button" disabled>Layer explorer</button>
+              <button class="btn btn-outline-secondary" type="button" disabled>Animation timeline</button>
+              <button class="btn btn-outline-secondary" type="button" disabled>Circuit coupling</button>
+            </div>
           </div>
-          <div class="col-md-4">
-            <label class="form-label" for="max-iters">Max iterations</label>
-            <input class="form-control" type="number" id="max-iters" name="max_iters" value="{{ default_max_iters }}" min="1" required>
-          </div>
         </div>
-        <div class="mb-3 mt-3">
-          <label class="form-label" for="outputs">Outputs (optional)</label>
-          <input class="form-control" type="text" id="outputs" name="outputs" placeholder="field_map">
-          <div class="form-text">Pass through to <code>motor_sim --outputs</code>; leave blank to use the solver default.</div>
-        </div>
-        <div class="d-flex gap-2">
-          <button id="run-btn" class="btn btn-primary" type="submit" {% if running %}disabled{% endif %}>Run simulation</button>
-          <button id="stop-btn" class="btn btn-warning" type="button" {% if not running %}disabled{% endif %}>Stop</button>
-        </div>
-      </form>
+      </div>
     </div>
-  </div>
-  <div id="progress-container" class="card card-body mb-3" style="display: none;">
-    <h2 class="h5">Progress</h2>
-    <div class="progress" style="height: 24px;">
-      <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;">0%</div>
+  </section>
+
+  <section id="geometry-preview" class="stage-section">
+    <div class="card card-elevated">
+      <div class="card-body">
+        <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+          <div>
+            <h5 class="card-title mb-0">Geometry preview</h5>
+            <p class="text-muted mb-0">Preview the domain layout before launching a solve.</p>
+          </div>
+          <span class="badge rounded-pill text-bg-secondary">Server rendered</span>
+        </div>
+        {% if preview_error %}
+          <div class="alert alert-danger" role="alert">{{ preview_error }}</div>
+        {% endif %}
+        {% if preview_notice %}
+          <div class="alert alert-success" role="alert">{{ preview_notice }}</div>
+        {% endif %}
+        <p id="preview-placeholder" class="text-muted small {% if preview_url %}d-none{% endif %}">
+          Upload or reuse a scenario and choose <strong>Preview geometry</strong> to render the layout.
+        </p>
+        {% set preview_src = preview_url %}
+        {% if preview_src and preview_token %}
+          {% if '?' in preview_src %}
+            {% set preview_src = preview_src ~ '&t=' ~ (preview_token|int) %}
+          {% else %}
+            {% set preview_src = preview_src ~ '?t=' ~ (preview_token|int) %}
+          {% endif %}
+        {% endif %}
+        <img
+          id="geometry-preview-image"
+          class="img-fluid rounded border {% if not preview_src %}d-none{% endif %}"
+          src="{{ preview_src or '' }}"
+          alt="Geometry preview"
+        >
+      </div>
+      <div class="card-footer text-muted small">DXF uploads will unlock richer previews in a future update.</div>
     </div>
-  </div>
-  <div id="log-container" class="card card-body mb-3" style="display: none;">
-    <h2 class="h5">Solver log</h2>
-    <pre id="log-area" class="bg-dark text-white p-3" style="max-height: 320px; overflow-y: auto;"></pre>
-  </div>
-  <div id="results" class="card card-body" style="display: none;">
-    <h2 class="h5">Downloads</h2>
-    <ul id="results-list" class="list-group list-group-flush"></ul>
-  </div>
+  </section>
+
+  <section id="simulation-setup" class="stage-section">
+    <div class="card card-elevated">
+      <div class="card-body">
+        <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+          <div>
+            <h5 class="card-title mb-0">Simulation setup</h5>
+            <p class="text-muted mb-0">Upload scenarios, adjust solver settings, and manage run controls.</p>
+          </div>
+          <span class="badge rounded-pill text-bg-primary">Stage 1 core</span>
+        </div>
+        {% if error %}
+          <div class="alert alert-danger" role="alert">{{ error }}</div>
+        {% endif %}
+        <form id="run-form" method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data" novalidate>
+          {% if project %}
+            <input type="hidden" name="project_id" value="{{ project.id }}">
+          {% endif %}
+          <div class="row g-3 align-items-end">
+            <div class="col-lg-6">
+              <label class="form-label" for="geometry-file">Scenario file (JSON)</label>
+              <input
+                class="form-control"
+                type="file"
+                id="geometry-file"
+                name="geometry_file"
+                accept=".json,.dxf"
+                {% if form_requires_file %}required{% endif %}
+              >
+              <div class="form-text">DXF ingestion arrives in a later stage. JSON scenarios are supported today.</div>
+              {% if has_project %}
+                <div class="small text-muted mt-2">Current scenario: <strong>{{ project.scenario_name or project.filename }}</strong></div>
+              {% endif %}
+            </div>
+            <div class="col-lg-6">
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label" for="solver">Solver</label>
+                  <select class="form-select" id="solver" name="solver">
+                    <option value="cg" {% if form_state.solver == 'cg' %}selected{% endif %}>Conjugate Gradient (CG)</option>
+                    <option value="sor" {% if form_state.solver == 'sor' %}selected{% endif %}>Successive Over-Relaxation (SOR)</option>
+                  </select>
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label" for="tol">Tolerance</label>
+                  <input class="form-control" type="number" step="any" id="tol" name="tol" value="{{ form_state.tol }}" required>
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label" for="max-iters">Max iterations</label>
+                  <input class="form-control" type="number" id="max-iters" name="max_iters" value="{{ form_state.max_iters }}" min="1" required>
+                </div>
+              </div>
+            </div>
+            <div class="col-12">
+              <label class="form-label" for="outputs">Requested outputs (optional)</label>
+              <input class="form-control" type="text" id="outputs" name="outputs" value="{{ form_state.outputs }}" placeholder="field_map">
+              <div class="form-text">Forwards to <code>motor_sim --outputs</code>; leave blank for scenario defaults.</div>
+            </div>
+          </div>
+          <div class="d-flex flex-wrap gap-2 mt-4">
+            <button id="run-btn" class="btn btn-primary" name="action" value="run" type="submit" {% if running %}disabled{% endif %}>Run simulation</button>
+            <button id="preview-btn" class="btn btn-outline-secondary" name="action" value="preview" type="submit" formnovalidate>Preview geometry</button>
+            <button id="stop-btn" class="btn btn-warning" type="button" {% if not running %}disabled{% endif %}>Stop</button>
+            <button class="btn btn-outline-secondary" type="button" disabled>Save preset (coming soon)</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <section id="progress-stage" class="stage-section">
+    <div class="row g-4">
+      <div class="col-xl-6">
+        <div id="progress-container" class="card card-elevated h-100" style="display: none;">
+          <div class="card-body">
+            <h5 class="card-title">Progress</h5>
+            <div class="progress" style="height: 24px;">
+              <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;">0%</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-xl-6">
+        <div id="log-container" class="card card-elevated h-100" style="display: none;">
+          <div class="card-body">
+            <h5 class="card-title">Solver log</h5>
+            <pre id="log-area" class="bg-dark text-white p-3 rounded" style="max-height: 320px; overflow-y: auto;"></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="results-stage" class="stage-section">
+    <div class="row g-4">
+      <div class="col-xl-4">
+        <div id="results" class="card card-elevated h-100" style="display: none;">
+          <div class="card-body">
+            <h5 class="card-title">Downloads</h5>
+            <ul id="results-list" class="list-group list-group-flush"></ul>
+          </div>
+        </div>
+      </div>
+      <div class="col-xl-8">
+        <div id="visualization-panel" class="card card-elevated h-100"{% if not visualization_visible %} style="display: none;"{% endif %}>
+          <div class="card-body">
+            <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+              <div>
+                <h5 class="card-title mb-0">Results visualisation</h5>
+                <p class="text-muted mb-0">Adjust overlays to explore the simulated field.</p>
+              </div>
+              <button class="btn btn-outline-secondary btn-sm" type="button" disabled>Share view (coming soon)</button>
+            </div>
+            <p id="visualization-message" class="text-muted small {% if last_visualization_url %}d-none{% endif %}">
+              {{ visualization_message or 'Run a simulation to generate field visualisations.' }}
+            </p>
+            <img id="result-image" class="img-fluid rounded border {% if not last_visualization_url %}d-none{% endif %}" src="{{ last_visualization_url or '' }}" alt="Field map visualisation">
+            <p id="visualization-caption" class="mt-2 text-muted small {% if not last_visualization_caption %}d-none{% endif %}">{{ last_visualization_caption }}</p>
+            <form id="visualization-form" class="row g-2 mt-3" data-endpoint="{{ url_for('visualization_image') }}">
+              <div class="col-md-3">
+                <label class="form-label small" for="vector-mode">Vector scaling</label>
+                <select class="form-select form-select-sm" id="vector-mode" name="vector">
+                  <option value="linear" {% if visualization_defaults.vector_mode == 'linear' %}selected{% endif %}>Linear</option>
+                  <option value="log" {% if visualization_defaults.vector_mode == 'log' %}selected{% endif %}>Logarithmic</option>
+                  <option value="off" {% if visualization_defaults.vector_mode == 'off' %}selected{% endif %}>Hidden</option>
+                </select>
+              </div>
+              <div class="col-md-3">
+                <label class="form-label small" for="color-scale">Colour scale</label>
+                <select class="form-select form-select-sm" id="color-scale" name="scale">
+                  <option value="linear" {% if visualization_defaults.color_scale == 'linear' %}selected{% endif %}>Linear</option>
+                  <option value="log" {% if visualization_defaults.color_scale == 'log' %}selected{% endif %}>Logarithmic</option>
+                </select>
+              </div>
+              <div class="col-md-2">
+                <label class="form-label small" for="quiver-skip">Arrow skip</label>
+                <input class="form-control form-control-sm" type="number" min="1" id="quiver-skip" name="skip" value="{{ visualization_defaults.quiver_skip }}">
+              </div>
+              <div class="col-md-2">
+                <label class="form-label small" for="log-floor">Log floor</label>
+                <input class="form-control form-control-sm" type="number" step="any" id="log-floor" name="log_floor" value="{{ '{:.1e}'.format(DEFAULT_LOG_FLOOR) }}">
+              </div>
+              <div class="col-md-2">
+                <label class="form-label small" for="vector-floor">Vector floor</label>
+                <input class="form-control form-control-sm" type="number" step="any" id="vector-floor" name="vector_floor" value="{{ '{:.1e}'.format(DEFAULT_LOG_FLOOR) }}">
+              </div>
+              <div class="col-md-12">
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="draw-boundaries" name="boundaries" value="1" {% if visualization_defaults.draw_boundaries %}checked{% endif %}>
+                  <label class="form-check-label small" for="draw-boundaries">Show region outlines</label>
+                </div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="checkbox" id="streamlines" name="stream" value="1" {% if visualization_defaults.streamlines %}checked{% endif %}>
+                  <label class="form-check-label small" for="streamlines">Streamlines</label>
+                </div>
+              </div>
+              <div class="col-12 d-flex flex-wrap gap-2">
+                <button id="update-visualization" class="btn btn-primary btn-sm" type="button" {% if not last_visualization_url %}disabled{% endif %}>Update visualisation</button>
+                <button class="btn btn-outline-secondary btn-sm" type="button" disabled>Save preset (coming soon)</button>
+              </div>
+            </form>
+            <div id="visualization-error" class="text-danger small mt-2 d-none"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 {% endblock %}
 
 {% block scripts %}
@@ -73,8 +268,42 @@
       const logArea = document.getElementById("log-area");
       const resultsContainer = document.getElementById("results");
       const resultsList = document.getElementById("results-list");
+      const visualizationPanel = document.getElementById("visualization-panel");
+      const visualizationMessage = document.getElementById("visualization-message");
+      const visualizationCaption = document.getElementById("visualization-caption");
+      const visualizationError = document.getElementById("visualization-error");
+      const resultImage = document.getElementById("result-image");
+      const updateVizBtn = document.getElementById("update-visualization");
+      const vizForm = document.getElementById("visualization-form");
       const downloadBase = "{{ url_for('download') }}";
       const isRunning = {{ 'true' if running else 'false' }};
+      let currentBlobUrl = null;
+
+      const navLinks = document.querySelectorAll('.app-sidebar .nav-link');
+      function setActiveNav(target) {
+        if (!target) {
+          target = '#project-overview';
+        }
+        navLinks.forEach(function (link) {
+          if (link.getAttribute('href') === target) {
+            link.classList.add('active');
+          } else {
+            link.classList.remove('active');
+          }
+        });
+      }
+
+      navLinks.forEach(function (link) {
+        link.addEventListener('click', function () {
+          setActiveNav(link.getAttribute('href'));
+        });
+      });
+
+      window.addEventListener('hashchange', function () {
+        setActiveNav(location.hash);
+      });
+
+      setActiveNav(location.hash);
 
       if (isRunning) {
         progressContainer.style.display = 'block';
@@ -84,7 +313,11 @@
       }
 
       if (runForm) {
-        runForm.addEventListener("submit", function () {
+        runForm.addEventListener("submit", function (event) {
+          const submitter = event.submitter;
+          if (submitter && submitter.value === 'preview') {
+            return;
+          }
           runBtn.disabled = true;
           stopBtn.disabled = false;
           progressContainer.style.display = 'block';
@@ -95,6 +328,24 @@
           progressBar.classList.remove('bg-danger', 'bg-success');
           progressBar.style.width = '0%';
           progressBar.textContent = '0%';
+          if (visualizationPanel) {
+            visualizationPanel.style.display = 'none';
+          }
+          if (visualizationMessage) {
+            visualizationMessage.classList.add('d-none');
+            visualizationMessage.textContent = '';
+          }
+          if (visualizationCaption) {
+            visualizationCaption.classList.add('d-none');
+            visualizationCaption.textContent = '';
+          }
+          if (visualizationError) {
+            visualizationError.classList.add('d-none');
+            visualizationError.textContent = '';
+          }
+          if (updateVizBtn) {
+            updateVizBtn.disabled = true;
+          }
         });
       }
 
@@ -168,8 +419,113 @@
               resultsList.appendChild(entry);
             });
           }
+          if (payload.visualization) {
+            handleVisualization(payload.visualization);
+          }
+        } else if (payload.visualization) {
+          handleVisualization(payload.visualization);
         }
       };
+
+      function handleVisualization(details) {
+        if (!details) {
+          return;
+        }
+        if (visualizationPanel) {
+          visualizationPanel.style.display = 'block';
+        }
+        if (visualizationError) {
+          visualizationError.classList.add('d-none');
+          visualizationError.textContent = '';
+        }
+        if (details.image) {
+          const url = details.image + (details.image.includes('?') ? '&' : '?') + 't=' + Date.now();
+          resultImage.src = url;
+          resultImage.classList.remove('d-none');
+          if (visualizationMessage) {
+            visualizationMessage.classList.add('d-none');
+          }
+          if (visualizationCaption) {
+            if (details.caption) {
+              visualizationCaption.textContent = details.caption;
+              visualizationCaption.classList.remove('d-none');
+            } else {
+              visualizationCaption.classList.add('d-none');
+            }
+          }
+          if (updateVizBtn) {
+            updateVizBtn.disabled = false;
+          }
+        } else if (details.message) {
+          if (visualizationMessage) {
+            visualizationMessage.textContent = details.message;
+            visualizationMessage.classList.remove('d-none');
+          }
+          resultImage.classList.add('d-none');
+          if (visualizationCaption) {
+            visualizationCaption.classList.add('d-none');
+          }
+          if (updateVizBtn) {
+            updateVizBtn.disabled = true;
+          }
+        }
+      }
+
+      if (updateVizBtn && vizForm) {
+        updateVizBtn.addEventListener('click', function () {
+          if (!vizForm.dataset.endpoint) {
+            return;
+          }
+          const formData = new FormData(vizForm);
+          if (!formData.has('boundaries')) {
+            formData.set('boundaries', document.getElementById('draw-boundaries').checked ? '1' : '0');
+          }
+          if (!formData.has('stream')) {
+            formData.set('stream', document.getElementById('streamlines').checked ? '1' : '0');
+          }
+          const params = new URLSearchParams(formData);
+          params.set('t', Date.now().toString());
+          const endpoint = vizForm.dataset.endpoint + '?' + params.toString();
+          updateVizBtn.disabled = true;
+          if (visualizationError) {
+            visualizationError.classList.add('d-none');
+            visualizationError.textContent = '';
+          }
+          fetch(endpoint)
+            .then(function (response) {
+              if (!response.ok) {
+                throw new Error('Request failed');
+              }
+              return response.blob();
+            })
+            .then(function (blob) {
+              if (currentBlobUrl) {
+                URL.revokeObjectURL(currentBlobUrl);
+              }
+              currentBlobUrl = URL.createObjectURL(blob);
+              if (visualizationPanel) {
+                visualizationPanel.style.display = 'block';
+              }
+              resultImage.src = currentBlobUrl;
+              resultImage.classList.remove('d-none');
+              if (visualizationMessage) {
+                visualizationMessage.classList.add('d-none');
+              }
+              if (visualizationCaption) {
+                visualizationCaption.classList.add('d-none');
+              }
+            })
+            .catch(function () {
+              if (visualizationError) {
+                visualizationError.textContent = 'Unable to refresh the visualisation.';
+                visualizationError.classList.remove('d-none');
+              }
+            })
+            .finally(function () {
+              updateVizBtn.disabled = false;
+            });
+        });
+      }
     });
   </script>
 {% endblock %}

--- a/python/gui/templates/index.html
+++ b/python/gui/templates/index.html
@@ -12,18 +12,27 @@
               <div class="alert alert-info" role="alert">{{ status_message }}</div>
             {% endif %}
             {% if has_project %}
-              <dl class="row small mb-0">
-                <dt class="col-sm-4 text-uppercase text-muted">Scenario name</dt>
-                <dd class="col-sm-8">{{ project.scenario_name or 'Unnamed scenario' }}</dd>
-                <dt class="col-sm-4 text-uppercase text-muted">Source file</dt>
-                <dd class="col-sm-8">{{ project.filename }}</dd>
-                <dt class="col-sm-4 text-uppercase text-muted">Created</dt>
-                <dd class="col-sm-8">{{ project.created_label }}</dd>
-                <dt class="col-sm-4 text-uppercase text-muted">Next steps</dt>
-                <dd class="col-sm-8">Preview the geometry or adjust solver settings before running the simulation.</dd>
-              </dl>
+              {% if project.has_scenario %}
+                <dl class="row small mb-0">
+                  <dt class="col-sm-4 text-uppercase text-muted">Scenario name</dt>
+                  <dd class="col-sm-8">{{ project.scenario_name or 'Unnamed scenario' }}</dd>
+                  <dt class="col-sm-4 text-uppercase text-muted">Source file</dt>
+                  <dd class="col-sm-8">{{ project.filename }}</dd>
+                  <dt class="col-sm-4 text-uppercase text-muted">Created</dt>
+                  <dd class="col-sm-8">{{ project.created_label }}</dd>
+                  <dt class="col-sm-4 text-uppercase text-muted">Next steps</dt>
+                  <dd class="col-sm-8">Preview the geometry, reconcile CAD layers, and configure solver controls.</dd>
+                </dl>
+              {% else %}
+                <p class="mb-3">This workspace is ready for CAD imports or a fresh scenario upload. Use the <strong>CAD workspace</strong> section to assemble layers before exporting a scenario.</p>
+                <ul class="text-muted small mb-0">
+                  <li>Import DXF files and assign layers to magnets, materials, and conductors.</li>
+                  <li>Generate previews to validate alignment prior to scenario creation.</li>
+                  <li>Upload a scenario JSON at any time to enable solver runs.</li>
+                </ul>
+              {% endif %}
             {% else %}
-              <p class="mb-3">Start a new project by uploading a scenario JSON file in the <strong>Simulation setup</strong> section. The File menu can be used to clear or export the active scenario.</p>
+              <p class="mb-3">Start a new project by uploading a scenario JSON file in the <strong>Simulation setup</strong> section or import CAD assets in the <strong>CAD workspace</strong>.</p>
               <ul class="text-muted small mb-0">
                 <li>Preview the geometry to ensure regions, magnets, and conductors look correct.</li>
                 <li>Adjust solver tolerances and iteration caps as needed.</li>
@@ -34,21 +43,144 @@
         </div>
       </div>
       <div class="col-xl-4">
-        <div class="card card-elevated h-100">
-          <div class="card-body">
-            <h6 class="text-uppercase text-muted mb-3">Coming soon</h6>
-            <p class="small text-muted">Stage&nbsp;2 of the overhaul will unlock more analysis tools. Placeholders are provided so future controls have a home.</p>
-            <div class="d-grid gap-2">
-              <button class="btn btn-outline-secondary" type="button" disabled>DXF import</button>
-              <button class="btn btn-outline-secondary" type="button" disabled>Layer explorer</button>
-              <button class="btn btn-outline-secondary" type="button" disabled>Animation timeline</button>
-              <button class="btn btn-outline-secondary" type="button" disabled>Circuit coupling</button>
+      <div class="card card-elevated h-100">
+        <div class="card-body">
+          <h6 class="text-uppercase text-muted mb-3">Coming soon</h6>
+          <p class="small text-muted">Upcoming milestones include animation tooling, circuit co-simulation, and shared preset libraries.</p>
+          <div class="d-grid gap-2">
+            <button class="btn btn-outline-secondary" type="button" disabled>Animation timeline</button>
+            <button class="btn btn-outline-secondary" type="button" disabled>Circuit coupling</button>
+            <button class="btn btn-outline-secondary" type="button" disabled>Shared presets</button>
+            <button class="btn btn-outline-secondary" type="button" disabled>Batch solves</button>
+          </div>
+        </div>
+      </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="cad-imports" class="stage-section">
+    <div class="card card-elevated">
+      <div class="card-body">
+        <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+          <div>
+            <h5 class="card-title mb-0">CAD workspace</h5>
+            <p class="text-muted mb-0">Import DXF files, assign layers, and preview combined geometry.</p>
+          </div>
+          <span class="badge rounded-pill text-bg-info">DXF tooling</span>
+        </div>
+        <form method="post" action="{{ url_for('upload_dxf_files') }}" enctype="multipart/form-data" class="mb-4">
+          {% if project %}
+            <input type="hidden" name="project_id" value="{{ project.id }}">
+          {% endif %}
+          <div class="row g-3 align-items-end">
+            <div class="col-lg-9">
+              <label class="form-label" for="dxf-files">DXF files</label>
+              <input class="form-control" type="file" id="dxf-files" name="dxf_files" accept=".dxf" multiple>
+              <div class="form-text">Upload one or more DXF files. Multi-part assemblies can be split across several uploads.</div>
             </div>
+            <div class="col-lg-3 d-grid">
+              <button class="btn btn-primary" type="submit">Import DXF</button>
+            </div>
+          </div>
+        </form>
+        {% if dxf_notice %}
+          <div class="alert alert-warning" role="alert">{{ dxf_notice }}</div>
+        {% endif %}
+        <div class="row g-4">
+          <div class="col-xl-6">
+            <h6 class="text-uppercase text-muted mb-3">Layer assignments</h6>
+            {% if dxf_files %}
+              {% for file in dxf_files %}
+                <div class="card border mb-3">
+                  <div class="card-body p-3">
+                    <div class="d-flex justify-content-between align-items-start mb-2">
+                      <div>
+                        <h6 class="mb-0">{{ file.name }}</h6>
+                        {% if file.uploaded_label %}
+                          <span class="text-muted small">Imported {{ file.uploaded_label }}</span>
+                        {% endif %}
+                      </div>
+                      <form method="post" action="{{ url_for('delete_dxf_entry', dxf_id=file.id) }}">
+                        {% if project %}
+                          <input type="hidden" name="project_id" value="{{ project.id }}">
+                        {% endif %}
+                        <button class="btn btn-outline-danger btn-sm" type="submit">Remove</button>
+                      </form>
+                    </div>
+                    <form method="post" action="{{ url_for('configure_dxf_layers', dxf_id=file.id) }}" class="layer-form">
+                      {% if project %}
+                        <input type="hidden" name="project_id" value="{{ project.id }}">
+                      {% endif %}
+                      <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-3">
+                          <thead>
+                            <tr class="text-muted small">
+                              <th scope="col">Include</th>
+                              <th scope="col">Layer</th>
+                              <th scope="col">Entities</th>
+                              <th scope="col">Category</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {% for layer in file.layers %}
+                              <tr>
+                                <td>
+                                  <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="layer-{{ layer.form_id }}-selected" name="layer-{{ layer.form_id }}-selected" {% if layer.selected %}checked{% endif %}>
+                                  </div>
+                                </td>
+                                <td>
+                                  <div class="fw-semibold small">{{ layer.name }}</div>
+                                  <div class="text-muted small">{{ layer.types | join(', ') }}</div>
+                                </td>
+                                <td class="small text-muted">{{ layer.entity_count }}</td>
+                                <td>
+                                  <select class="form-select form-select-sm" name="layer-{{ layer.form_id }}-category">
+                                    {% for value, label in dxf_categories %}
+                                      <option value="{{ value }}" {% if layer.category == value %}selected{% endif %}>{{ label }}</option>
+                                    {% endfor %}
+                                  </select>
+                                </td>
+                              </tr>
+                            {% endfor %}
+                          </tbody>
+                        </table>
+                      </div>
+                      <div class="d-grid d-sm-flex gap-2">
+                        <button class="btn btn-outline-primary btn-sm" type="submit">Update mapping</button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              {% endfor %}
+            {% else %}
+              <p class="text-muted small mb-0">No DXF files have been imported yet. Upload CAD geometry to begin mapping layers.</p>
+            {% endif %}
+          </div>
+          <div class="col-xl-6">
+            <h6 class="text-uppercase text-muted mb-3">Combined preview</h6>
+            {% set cad_preview_src = dxf_preview_url %}
+            {% if cad_preview_src and dxf_preview_token %}
+              {% if '?' in cad_preview_src %}
+                {% set cad_preview_src = cad_preview_src ~ '&t=' ~ (dxf_preview_token|int) %}
+              {% else %}
+                {% set cad_preview_src = cad_preview_src ~ '?t=' ~ (dxf_preview_token|int) %}
+              {% endif %}
+            {% endif %}
+            {% if cad_preview_src %}
+              <img class="img-fluid rounded border" src="{{ cad_preview_src }}" alt="DXF preview">
+            {% elif has_dxf_selection %}
+              <p class="text-muted small">Selected layers have no drawable geometry yet. Adjust the mapping or source files.</p>
+            {% else %}
+              <p class="text-muted small">Select layers and save the mapping to generate a combined preview.</p>
+            {% endif %}
           </div>
         </div>
       </div>
     </div>
   </section>
+
 
   <section id="geometry-preview" class="stage-section">
     <div class="card card-elevated">
@@ -84,7 +216,7 @@
           alt="Geometry preview"
         >
       </div>
-      <div class="card-footer text-muted small">DXF uploads will unlock richer previews in a future update.</div>
+      <div class="card-footer text-muted small">Use CAD workspace uploads to stage geometry before exporting a scenario.</div>
     </div>
   </section>
 
@@ -116,7 +248,7 @@
                 accept=".json,.dxf"
                 {% if form_requires_file %}required{% endif %}
               >
-              <div class="form-text">DXF ingestion arrives in a later stage. JSON scenarios are supported today.</div>
+              <div class="form-text">Use JSON scenarios for solver runs. Manage CAD layers in the CAD workspace.</div>
               {% if has_project %}
                 <div class="small text-muted mt-2">Current scenario: <strong>{{ project.scenario_name or project.filename }}</strong></div>
               {% endif %}

--- a/python/visualize_scenario_field.py
+++ b/python/visualize_scenario_field.py
@@ -9,7 +9,7 @@ import json
 import pathlib
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, IO, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
@@ -461,7 +461,7 @@ def plot_field(
     bmag: np.ndarray,
     wires: List[Wire],
     quiver_skip: int,
-    save: pathlib.Path | None,
+    save: pathlib.Path | IO[bytes] | None,
     title: str,
     color_scale: str,
     log_floor: float,
@@ -473,6 +473,8 @@ def plot_field(
     streamlines: bool,
     analytic: Optional[Dict[str, np.ndarray]],
     analytic_levels: int,
+    *,
+    show: bool = True,
 ) -> None:
     fig, ax = plt.subplots(figsize=(7, 6))
     display_mag = bmag
@@ -575,9 +577,13 @@ def plot_field(
 
     if save is not None:
         fig.savefig(save, dpi=200, bbox_inches="tight")
-        print(f"Saved figure to {save}")
+        if isinstance(save, pathlib.Path):
+            print(f"Saved figure to {save}")
 
-    plt.show()
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
 
 
 def main() -> None:

--- a/scripts/maintain_gui_env.sh
+++ b/scripts/maintain_gui_env.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Light-weight housekeeping for the Flask GUI runtime assets.
+#
+# The script prunes stale uploads/results and surfaces dependency
+# inconsistencies so environments stay clean between simulation runs.
+#
+# Usage:
+#   ./scripts/maintain_gui_env.sh [days-to-keep]
+#   KEEP_DAYS=3 ./scripts/maintain_gui_env.sh
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+KEEP_DAYS=${1:-${KEEP_DAYS:-7}}
+UPLOAD_DIR="${ROOT_DIR}/python/gui/uploads"
+RESULTS_DIR="${ROOT_DIR}/python/gui/results"
+PYTHON_BIN=${PYTHON:-python3}
+
+prune_dir() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    find "$path" -type f -mtime "+${KEEP_DAYS}" -print -delete
+  fi
+}
+
+prune_dir "$UPLOAD_DIR"
+prune_dir "$RESULTS_DIR"
+
+"${PYTHON_BIN}" -m pip check >/dev/null
+
+echo "[maintain_gui_env] Removed artefacts older than ${KEEP_DAYS} day(s)."
+
+outdated=$("${PYTHON_BIN}" -m pip list --outdated)
+if [[ $(echo "$outdated" | awk 'END {print NR}') -gt 2 ]]; then
+  echo "[maintain_gui_env] The following packages can be updated:" >&2
+  echo "$outdated" >&2
+else
+  echo "[maintain_gui_env] All installed packages are up to date." >&2
+fi

--- a/scripts/setup_gui_env.sh
+++ b/scripts/setup_gui_env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap dependencies required by the Flask GUI prototype.
+#
+# Usage:
+#   ./scripts/setup_gui_env.sh [python-executable]
+#   PYTHON=python3.11 ./scripts/setup_gui_env.sh
+#
+# When no interpreter is supplied the script defaults to the current
+# environment's "python3". The command installs Flask, Matplotlib and
+# NumPy so the GUI can render previews and field maps. It also prepares the
+# runtime directories used to store uploads and generated artefacts.
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PYTHON_BIN=${1:-${PYTHON:-python3}}
+
+"${PYTHON_BIN}" -m pip install --upgrade pip
+"${PYTHON_BIN}" -m pip install --upgrade \
+  flask \
+  matplotlib \
+  numpy
+
+mkdir -p "${ROOT_DIR}/python/gui/uploads" "${ROOT_DIR}/python/gui/results"
+
+cat <<SETUP_MSG
+[setup_gui_env] Installed Flask GUI runtime dependencies using ${PYTHON_BIN}.
+[setup_gui_env] Upload/result directories are ready under python/gui/.
+SETUP_MSG

--- a/scripts/setup_gui_env.sh
+++ b/scripts/setup_gui_env.sh
@@ -19,11 +19,12 @@ PYTHON_BIN=${1:-${PYTHON:-python3}}
 "${PYTHON_BIN}" -m pip install --upgrade \
   flask \
   matplotlib \
-  numpy
+  numpy \
+  ezdxf
 
 mkdir -p "${ROOT_DIR}/python/gui/uploads" "${ROOT_DIR}/python/gui/results"
 
 cat <<SETUP_MSG
-[setup_gui_env] Installed Flask GUI runtime dependencies using ${PYTHON_BIN}.
+[setup_gui_env] Installed Flask GUI runtime dependencies (Flask, Matplotlib, NumPy, ezdxf) using ${PYTHON_BIN}.
 [setup_gui_env] Upload/result directories are ready under python/gui/.
 SETUP_MSG

--- a/tests/test_gui_flask.py
+++ b/tests/test_gui_flask.py
@@ -1,12 +1,14 @@
 import io
 import json
 import queue
-import time
 import sys
+import time
 from pathlib import Path
 from typing import List
 
 import pytest
+
+pytest.importorskip("flask")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -22,14 +24,57 @@ def _reset_manager(tmp_path, monkeypatch):
     app_flask.app.config["UPLOAD_FOLDER"] = str(uploads)
     app_flask.app.config["RESULTS_FOLDER"] = str(results)
     app_flask.manager.reset()
+    app_flask.PROJECTS.clear()
     yield
     app_flask.manager.reset()
+    app_flask.PROJECTS.clear()
 
 
 @pytest.fixture
 def client():
     with app_flask.app.test_client() as test_client:
         yield test_client
+
+
+@pytest.fixture
+def visualization_ready(tmp_path):
+    scenario = tmp_path / "viz_scenario.json"
+    scenario.write_text(
+        json.dumps(
+            {
+                "version": "0.2",
+                "name": "visualisation fixture",
+                "domain": {"Lx": 0.1, "Ly": 0.1},
+                "sources": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    field_map = tmp_path / "outputs" / "fixture_field.csv"
+    field_map.parent.mkdir(parents=True, exist_ok=True)
+    field_map.write_text(
+        "x,y,Bx,By,Bmag\n"
+        "0.0,0.0,0.1,0.0,0.1\n"
+        "0.0,0.1,0.1,0.0,0.1\n"
+        "0.1,0.0,0.1,0.0,0.1\n"
+        "0.1,0.1,0.1,0.0,0.1\n",
+        encoding="utf-8",
+    )
+
+    app_flask.manager._last_result = {  # type: ignore[attr-defined]
+        "scenario_path": str(scenario),
+        "field_map": str(field_map),
+        "settings": {
+            "vector_mode": app_flask.DEFAULT_VECTOR_MODE,
+            "color_scale": app_flask.DEFAULT_COLOR_SCALE,
+            "quiver_skip": app_flask.DEFAULT_QUIVER_SKIP,
+            "draw_boundaries": True,
+            "streamlines": False,
+        },
+    }
+
+    return {"scenario": scenario, "field_map": field_map}
 
 
 def test_upload_starts_simulation(monkeypatch, client):
@@ -88,6 +133,324 @@ def test_upload_starts_simulation(monkeypatch, client):
     assert any(evt.get("started") for evt in events)
     assert any(evt.get("complete") for evt in events)
     assert not app_flask.manager.is_running
+
+
+def test_preview_generates_geometry_image(client):
+    payload = json.dumps(
+        {
+            "version": "0.2",
+            "domain": {"Lx": 0.2, "Ly": 0.1},
+            "sources": [],
+        }
+    ).encode("utf-8")
+
+    response = client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(payload), "preview.json"),
+            "solver": "cg",
+            "tol": "1e-6",
+            "max_iters": "100",
+            "action": "preview",
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    body = response.data.decode("utf-8")
+    assert "geometry-preview-image" in body
+    results_dir = Path(app_flask.app.config["RESULTS_FOLDER"])
+    generated = list(results_dir.glob("geometry_preview_*.png"))
+    assert generated, "Expected a preview image to be created"
+    with client.session_transaction() as session:
+        project_id = session.get("project_id")
+    assert project_id in app_flask.PROJECTS
+
+
+def test_preview_invalid_json_reports_error(client):
+    response = client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(b"not-json"), "invalid.json"),
+            "action": "preview",
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Uploaded JSON is invalid" in response.get_data(as_text=True)
+
+
+def test_run_after_preview_without_new_upload(monkeypatch, client):
+    popen_calls: List[List[str]] = []
+
+    class DummyProcess:
+        def __init__(self) -> None:
+            self.stdout = io.StringIO("10%\nFinished\n")
+            self.returncode = 0
+            self.terminated = False
+
+        def wait(self) -> int:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+    def fake_popen(cmd, **kwargs):  # noqa: ANN001 - signature mirrors subprocess
+        popen_calls.append(cmd)
+        return DummyProcess()
+
+    monkeypatch.setattr(app_flask.subprocess, "Popen", fake_popen)
+
+    scenario_payload = json.dumps({"version": "0.2", "domain": {"Lx": 0.1, "Ly": 0.1}, "sources": []}).encode(
+        "utf-8"
+    )
+
+    preview_response = client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(scenario_payload), "reuse.json"),
+            "solver": "cg",
+            "tol": "1e-6",
+            "max_iters": "50",
+            "action": "preview",
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert preview_response.status_code == 200
+    with client.session_transaction() as session:
+        project_id = session.get("project_id")
+
+    assert project_id in app_flask.PROJECTS
+    stored_path = app_flask.PROJECTS[project_id]["scenario_path"]
+
+    response = client.post(
+        "/upload",
+        data={
+            "project_id": project_id,
+            "solver": "cg",
+            "tol": "1e-6",
+            "max_iters": "5",
+            "action": "run",
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 302
+
+    deadline = time.time() + 1
+    while time.time() < deadline and not popen_calls:
+        time.sleep(0.01)
+
+    assert popen_calls, "subprocess.Popen should run without re-uploading"
+    assert str(stored_path) in popen_calls[0]
+
+
+def test_visualization_route_after_run(monkeypatch, client):
+    stdout_queue: "queue.Queue[str | None]" = queue.Queue()
+
+    class DummyStdout:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            item = stdout_queue.get()
+            if item is None:
+                raise StopIteration
+            return item
+
+    class DummyProcess:
+        def __init__(self) -> None:
+            self.stdout = DummyStdout()
+            self.returncode = 0
+
+        def wait(self) -> int:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.returncode = 143
+
+    def fake_popen(cmd, **kwargs):  # noqa: ANN001 - signature mirrors subprocess
+        return DummyProcess()
+
+    monkeypatch.setattr(app_flask.subprocess, "Popen", fake_popen)
+
+    scenario_payload = json.dumps(
+        {
+            "version": "0.2",
+            "domain": {"Lx": 0.1, "Ly": 0.1},
+            "sources": [
+                {"type": "wire", "x": 0.0, "y": 0.0, "radius": 0.002, "I": 5.0}
+            ],
+            "outputs": [
+                {
+                    "type": "field_map",
+                    "id": "domain_field",
+                    "path": "outputs/test_field.csv",
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+    response = client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(scenario_payload), "scenario.json"),
+            "solver": "cg",
+            "tol": "1e-6",
+            "max_iters": "100",
+            "outputs": "domain_field",
+        },
+        content_type="multipart/form-data",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    deadline = time.time() + 2
+    scenario_path: Path | None = None
+    while time.time() < deadline:
+        scenario = app_flask.manager._metadata.get("scenario_path")  # type: ignore[attr-defined]
+        if isinstance(scenario, Path):
+            scenario_path = scenario
+            break
+        time.sleep(0.01)
+
+    assert scenario_path is not None
+
+    field_path = scenario_path.parent / "outputs" / "test_field.csv"
+    field_path.parent.mkdir(parents=True, exist_ok=True)
+    field_path.write_text(
+        "x,y,Bx,By,Bmag\n"
+        "0.0,0.0,0.1,0.0,0.1\n"
+        "0.05,0.0,0.1,0.0,0.1\n"
+        "0.0,0.05,0.1,0.0,0.1\n"
+        "0.05,0.05,0.1,0.0,0.1\n",
+        encoding="utf-8",
+    )
+
+    stdout_queue.put("10%\n")
+    stdout_queue.put("Frame 0: wrote field_map 'domain_field' to \"outputs/test_field.csv\"\n")
+    stdout_queue.put("Finished\n")
+    stdout_queue.put(None)
+
+    events = []
+    deadline = time.time() + 3
+    while time.time() < deadline:
+        try:
+            item = app_flask.manager.queue.get(timeout=0.1)
+            events.append(item)
+            if item.get("complete"):
+                break
+        except queue.Empty:
+            pass
+
+    assert any("visualization" in evt for evt in events if isinstance(evt, dict))
+    last_result = app_flask.manager.get_last_result()
+    assert Path(last_result.get("field_map", "")).exists()
+
+    viz_response = client.get(
+        "/visualization.png",
+        query_string={"vector": "off", "boundaries": "0", "skip": "2"},
+    )
+    assert viz_response.status_code == 200
+    assert viz_response.mimetype == "image/png"
+    payload = b"".join(viz_response.response)
+    assert payload, "Expected PNG bytes from visualisation route"
+
+
+def test_project_scenario_download(client):
+    payload = json.dumps({"version": "0.2", "domain": {"Lx": 0.1, "Ly": 0.1}, "sources": []}).encode("utf-8")
+
+    client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(payload), "download.json"),
+            "action": "preview",
+        },
+        content_type="multipart/form-data",
+    )
+
+    with client.session_transaction() as session:
+        project_id = session.get("project_id")
+
+    assert project_id in app_flask.PROJECTS
+    scenario_path = app_flask.PROJECTS[project_id]["scenario_path"]
+    response = client.get("/project/scenario")
+    assert response.status_code == 200
+    assert response.data == scenario_path.read_bytes()
+    assert "download" in response.headers.get("Content-Disposition", "")
+
+
+def test_project_reset_clears_state(client):
+    payload = json.dumps({"version": "0.2", "domain": {"Lx": 0.1, "Ly": 0.1}, "sources": []}).encode("utf-8")
+
+    client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(payload), "reset.json"),
+            "action": "preview",
+        },
+        content_type="multipart/form-data",
+    )
+
+    with client.session_transaction() as session:
+        project_id = session.get("project_id")
+
+    scenario_path = app_flask.PROJECTS[project_id]["scenario_path"]
+    assert scenario_path.exists()
+
+    response = client.post("/project/reset")
+    assert response.status_code == 302
+    assert "notice=Project+cleared." in response.headers.get("Location", "")
+
+    with client.session_transaction() as session:
+        assert "project_id" not in session
+
+    assert project_id not in app_flask.PROJECTS
+    assert not scenario_path.exists()
+
+
+def test_project_reset_requires_idle(client):
+    app_flask.manager._running = True  # type: ignore[attr-defined]
+    try:
+        response = client.post("/project/reset")
+        assert response.status_code == 302
+        assert "error=Stop+the+running+simulation" in response.headers.get("Location", "")
+    finally:
+        app_flask.manager._running = False  # type: ignore[attr-defined]
+
+
+def test_visualization_route_rejects_invalid_params(visualization_ready, client):
+    response = client.get("/visualization.png", query_string={"vector": "bad"})
+    assert response.status_code == 400
+
+    response = client.get("/visualization.png", query_string={"skip": "0"})
+    assert response.status_code == 400
+
+    response = client.get("/visualization.png", query_string={"scale": "bad"})
+    assert response.status_code == 400
+
+
+def test_visualization_route_accepts_streamlines(visualization_ready, client):
+    response = client.get(
+        "/visualization.png",
+        query_string={
+            "vector": "linear",
+            "skip": "2",
+            "scale": "log",
+            "boundaries": "0",
+            "stream": "1",
+            "log_floor": "1e-9",
+            "vector_floor": "1e-9",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.mimetype == "image/png"
+    assert b"".join(response.response)
 
 
 def test_stop_route_terminates_process(client):

--- a/tests/test_gui_flask.py
+++ b/tests/test_gui_flask.py
@@ -3,9 +3,11 @@ import json
 import queue
 import sys
 import time
+import zipfile
 from pathlib import Path
 from typing import List
 
+import ezdxf
 import pytest
 
 pytest.importorskip("flask")
@@ -484,3 +486,104 @@ def test_progress_stream_emits_payloads(client):
 
     assert b"hello" in body
     assert b"done" in body
+
+
+def test_dxf_upload_preview_and_delete(client, tmp_path):
+    doc = ezdxf.new("R2010")
+    msp = doc.modelspace()
+    msp.add_lwpolyline([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)], dxfattribs={"layer": "domain"})
+    msp.add_circle((0.5, 0.5), 0.1, dxfattribs={"layer": "wire"})
+    dxf_path = tmp_path / "fixture.dxf"
+    doc.saveas(dxf_path)
+
+    with dxf_path.open("rb") as handle:
+        response = client.post(
+            "/dxf/upload",
+            data={"dxf_files": [(handle, "fixture.dxf")]},
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 302
+
+    with client.session_transaction() as session:
+        project_id = session.get("project_id")
+
+    assert project_id in app_flask.PROJECTS
+    project = app_flask.PROJECTS[project_id]
+    assert project["dxf_files"], "DXF uploads should register with the project"
+
+    entry_id, entry = next(iter(project["dxf_files"].items()))
+    preview_path = project.get("dxf_preview_path")
+    assert isinstance(preview_path, Path) and preview_path.exists()
+
+    original_version = project.get("dxf_preview_version")
+    layer_form_data = {"project_id": project_id}
+    for layer in entry["layers"]:
+        form_id = layer["form_id"]
+        category = "material" if layer["name"].lower() == "domain" else "wire"
+        layer_form_data[f"layer-{form_id}-category"] = category
+        if layer["name"].lower() == "domain":
+            # Unselect the boundary to exercise deselection logic.
+            continue
+        layer_form_data[f"layer-{form_id}-selected"] = "on"
+
+    response = client.post(
+        f"/dxf/{entry_id}/layers",
+        data=layer_form_data,
+        content_type="application/x-www-form-urlencoded",
+    )
+
+    assert response.status_code == 302
+    updated_entry = app_flask.PROJECTS[project_id]["dxf_files"][entry_id]
+    assert any(layer["selected"] for layer in updated_entry["layers"])
+    assert original_version != app_flask.PROJECTS[project_id].get("dxf_preview_version")
+
+    response = client.post(
+        f"/dxf/{entry_id}/delete",
+        data={"project_id": project_id},
+        content_type="application/x-www-form-urlencoded",
+    )
+
+    assert response.status_code == 302
+    assert entry_id not in app_flask.PROJECTS[project_id]["dxf_files"]
+
+
+def test_project_export_dxf_generates_archive(client, tmp_path):
+    scenario_payload = json.dumps(
+        {
+            "version": "0.2",
+            "name": "exportable",
+            "domain": {"Lx": 0.2, "Ly": 0.1},
+            "sources": [
+                {"type": "wire", "x": 0.0, "y": 0.0, "radius": 0.01, "I": 10.0},
+            ],
+            "regions": [
+                {
+                    "type": "polygon",
+                    "material": "iron",
+                    "points": [[-0.08, -0.04], [0.08, -0.04], [0.08, 0.04], [-0.08, 0.04]],
+                }
+            ],
+            "magnets": [],
+        }
+    ).encode("utf-8")
+
+    client.post(
+        "/upload",
+        data={
+            "geometry_file": (io.BytesIO(scenario_payload), "export.json"),
+            "action": "preview",
+        },
+        content_type="multipart/form-data",
+    )
+
+    response = client.get("/project/export_dxf")
+
+    assert response.status_code == 200
+    assert response.mimetype in {"application/zip", "application/octet-stream"}
+    payload = b"".join(response.response)
+    assert payload, "Expected non-empty archive payload"
+
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        names = set(archive.namelist())
+    assert {"domain.dxf"}.issubset(names)


### PR DESCRIPTION
## Summary
- restructure the Flask templates into a top navigation bar, workflow sidebar, and staged panels for preview, setup, progress, and results
- persist scenario uploads as reusable projects with reset/export routes while tightening field-map detection and SSE visual updates
- expand the GUI documentation, agent guidance, and pytest coverage for project reuse, downloads, and layout behaviour

## Testing
- pytest tests/test_gui_flask.py

------
https://chatgpt.com/codex/tasks/task_e_68f87495d1c08331a54aefc27808404f